### PR TITLE
Allow non-constant strings in test case names

### DIFF
--- a/lib-clay/test/test.clay
+++ b/lib-clay/test/test.clay
@@ -7,10 +7,13 @@ record TestStatus (
 overload TestStatus() = TestStatus(UInt(0), UInt(0), UInt(0));
 
 record TestCase (
-    name: StringConstant,
+    name: String,
     _case: Lambda[(TestStatus), ()],
     pending?: Bool,
 );
+
+[T | String?(T) and T != String]
+overload TestCase(name : T, _case, pending?) TestCase = TestCase(String(name), _case, pending?);
 
 overload TestCase(name, fn) = TestCase(name, Lambda[(TestStatus), ()](fn), false);
 


### PR DESCRIPTION
I have something I'm writing tests for where I want to be able to generate test cases (essentially every possible value begets a test, and I would like to generate "test for value blah" for a wide range of blah), but TestCase currently requires a StringConstant as its name, which is frustrating and seems uneccessary.

This patch simply makes TestCase take a String, and overloads the constructor so that it can accept anything string-like as the name (in particular string constants still work). 
