### PR TITLE
Custom comparators for sorting

### DIFF
--- a/lib-clay/algorithms/algorithms.clay
+++ b/lib-clay/algorithms/algorithms.clay
@@ -383,6 +383,10 @@ overload binarySearchUpperBound(begin_, end_, x) {
 //
 
 [A | RandomAccessSequence?(A)]
-sort(a:A) {
-    introsort.introSort(a);
+sort(a:A, compareLess?) {
+    introsort.introSort(a, compareLess?);
+}
+
+overload sort(a){
+  sort(a, lesser?);
 }

--- a/lib-clay/algorithms/heaps/heaps.clay
+++ b/lib-clay/algorithms/heaps/heaps.clay
@@ -1,15 +1,15 @@
-heapSelect(first_, middle_, last_) {
+heapSelect(first_, middle_, last_, compareLess?) {
     var first, middle, last = first_, middle_, last_;
-    makeHeap(first, middle);
+    makeHeap(first, middle, compareLess?);
     var i = middle;
     while (i < last) {
         if (i^ < first^)
-            popHeap(first, middle, i);
+            popHeap(first, middle, i, compareLess?);
         i += 1;
     }
 }
 
-makeHeap(first_, last_) {
+makeHeap(first_, last_, compareLess?) {
     var first, last = first_, last_;
     if (last - first < 2)
         return;
@@ -17,34 +17,34 @@ makeHeap(first_, last_) {
     var parent = (len - 2) / 2;
     while (true) {
         var value = move((first + parent)^);
-        adjustHeap(first, parent, len, move(value));
+        adjustHeap(first, parent, len, move(value), compareLess?);
         if (parent == 0)
             return;
         parent -= 1;
     }
 }
 
-sortHeap(first_, last_) {
+sortHeap(first_, last_, compareLess?) {
     var first, last = first_, last_;
     while (last - first > 1) {
         last -= 1;
-        popHeap(first, last, last);
+        popHeap(first, last, last, compareLess?);
     }
 }
 
-popHeap(first_, last_, result_) {
+popHeap(first_, last_, result_, compareLess?) {
     var first, last, result = first_, last_, result_;
     var value = move(result^);
     result^ = move(first^);
     alias DistanceType = Type(last - first);
-    adjustHeap(first, DistanceType(0), last-first, move(value));
+    adjustHeap(first, DistanceType(0), last-first, move(value), compareLess?);
 }
 
-pushHeap(first_, holeIndex_, topIndex_, rvalue value_) {
+pushHeap(first_, holeIndex_, topIndex_, rvalue value_, compareLess?) {
     var first, holeIndex, topIndex, value =
         first_, holeIndex_, topIndex_, move(value_);
     var parent = (holeIndex - 1) / 2;
-    while ((holeIndex > topIndex) and ((first + parent)^ < value)) {
+    while ((holeIndex > topIndex) and compareLess?((first + parent)^, value)) {
         (first + holeIndex)^ = move((first + parent)^);
         holeIndex = parent;
         parent = (holeIndex - 1) / 2;
@@ -52,13 +52,13 @@ pushHeap(first_, holeIndex_, topIndex_, rvalue value_) {
     (first + holeIndex)^ = move(value);
 }
 
-adjustHeap(first_, holeIndex_, len_, rvalue value_) {
+adjustHeap(first_, holeIndex_, len_, rvalue value_, compareLess?) {
     var first, holeIndex, len, value = first_, holeIndex_, len_, move(value_);
     var topIndex = holeIndex;
     var secondChild = holeIndex;
     while (secondChild < (len - 1)/2) {
         secondChild = 2 * (secondChild + 1);
-        if ((first + secondChild)^ < (first + secondChild - 1)^)
+        if(compareLess?((first + secondChild)^, (first + secondChild - 1)^))
             secondChild -= 1;
         (first + holeIndex)^ = move((first + secondChild)^);
         holeIndex = secondChild;
@@ -68,5 +68,5 @@ adjustHeap(first_, holeIndex_, len_, rvalue value_) {
         (first + holeIndex)^ = move((first + (secondChild - 1))^);
         holeIndex = secondChild - 1;
     }
-    pushHeap(first, holeIndex, topIndex, move(value));
+    pushHeap(first, holeIndex, topIndex, move(value), compareLess?);
 }

--- a/lib-clay/algorithms/introsort/introsort.clay
+++ b/lib-clay/algorithms/introsort/introsort.clay
@@ -1,13 +1,13 @@
 import algorithms.heaps.*;
 
-introSort(a) {
-    introSort(begin(a), end(a));
+introSort(a, compareLess?) {
+    introSort(begin(a), end(a), compareLess?);
 }
 
-overload introSort(first, last) {
+overload introSort(first, last, compareLess?) {
     if (first != last) {
-        introSortLoop(first, last, log2(last-first)*2);
-        finalInsertionSort(first, last);
+        introSortLoop(first, last, log2(last-first)*2, compareLess?);
+        finalInsertionSort(first, last, compareLess?);
     }
 }
 
@@ -23,53 +23,54 @@ log2(x) {
 
 alias threshold = 32;
 
-introSortLoop(first_, last_, depthLimit_) {
+introSortLoop(first_, last_, depthLimit_, compareLess?) {
     var first, last, depthLimit = first_, last_, depthLimit_;
     while (last - first > threshold) {
         if (depthLimit == 0) {
-            partialSort(first, last, last);
+            partialSort(first, last, last, compareLess?
+);
             return;
         }
         depthLimit -= 1;
-        var cut = unguardedPartitionPivot(first, last);
-        introSortLoop(cut+1, last, depthLimit);
+        var cut = unguardedPartitionPivot(first, last, compareLess?);
+        introSortLoop(cut+1, last, depthLimit, compareLess?);
         last = cut;
     }
 }
 
-unguardedPartitionPivot(first_, last_) {
+unguardedPartitionPivot(first_, last_, compareLess?) {
     var first, last = first_, last_;
     var mid = first + (last - first)/2;
-    moveMedianFirst(first, mid, last-1);
-    var cut = unguardedPartition(first + 1, last, first^);
+    moveMedianFirst(first, mid, last-1, compareLess?);
+    var cut = unguardedPartition(first + 1, last, first^, compareLess?);
     cut -= 1;
     swap(first^, cut^);
     return cut;
 }
 
-moveMedianFirst(a_, b_, c_) {
+moveMedianFirst(a_, b_, c_, compareLess?) {
     var a, b, c = a_, b_, c_;
-    if (a^ < b^) {
-        if (b^ < c^)
+    if (compareLess?(a^,  b^)) {
+        if (compareLess?(b^, c^))
             swap(a^, b^);
-        else if (a^ < c^)
+        else if (compareLess?(a^, c^))
             swap(a^, c^);
     }
-    else if (a^ < c^)
+    else if (compareLess?(a^,  c^))
         return;
-    else if (b^ < c^)
+    else if (compareLess?(b^, c^))
         swap(a^, c^);
     else
         swap(a^, b^);
 }
 
-unguardedPartition(first_, last_, pivot) {
+unguardedPartition(first_, last_, pivot, compareLess?) {
     var first, last = first_, last_;
     while (true) {
-        while (first^ < pivot)
+        while (compareLess?(first^, pivot))
             first += 1;
         last -= 1;
-        while (pivot < last^)
+        while (compareLess?(pivot, last^))
             last -= 1;
         if (not (first < last))
             break;
@@ -79,54 +80,54 @@ unguardedPartition(first_, last_, pivot) {
     return first;
 }
 
-finalInsertionSort(first_, last_) {
+finalInsertionSort(first_, last_, compareLess?) {
     var first, last = first_, last_;
     if (last - first > threshold) {
-        insertionSort(first, first + threshold);
-        unguardedInsertionSort(first + threshold, last);
+        insertionSort(first, first + threshold, compareLess?);
+        unguardedInsertionSort(first + threshold, last, compareLess?);
     }
     else {
-        insertionSort(first, last);
+        insertionSort(first, last, compareLess?);
     }
 }
 
-insertionSort(a) {
-    insertionSort(begin(a), end(a));
+insertionSort(a, compareLess?) {
+    insertionSort(begin(a), end(a), compareLess?);
 }
 
-overload insertionSort(first_, last_) {
+overload insertionSort(first_, last_, compareLess?) {
     var first, last = first_, last_;
     if (first == last)
         return;
     var i = first + 1;
     while (i != last) {
-        if (i^ < first^) {
+        if (compareLess?(i^, first^)) {
             var value = move(i^);
             moveBackward(first, i, i+1);
             first^ = move(value);
         }
         else {
-            unguardedLinearInsert(i);
+            unguardedLinearInsert(i, compareLess?);
         }
         i += 1;
     }
 }
 
-unguardedInsertionSort(first_, last_) {
+unguardedInsertionSort(first_, last_, compareLess?) {
     var first, last = first_, last_;
     var i = first;
     while (i != last) {
-        unguardedLinearInsert(i);
+        unguardedLinearInsert(i, compareLess?);
         i += 1;
     }
 }
 
-unguardedLinearInsert(last_) {
+unguardedLinearInsert(last_, compareLess?) {
     var last = last_;
     var value = move(last^);
     var next = last;
     next -= 1;
-    while (value < next^) {
+    while (compareLess?(value, next^)) {
         last^ = move(next^);
         last = next;
         next -= 1;
@@ -148,13 +149,13 @@ heapSort(a) {
     heapSort(begin(a), end(a));
 }
 
-overload heapSort(first, last) {
-    partialSort(first, last, last);
+overload heapSort(first, last, compareLess?) {
+    partialSort(first, last, last, compareLess?);
 }
 
-partialSort(first_, middle_, last_) {
+partialSort(first_, middle_, last_, compareLess?) {
     var first, middle, last = first_, middle_, last_;
-    heapSelect(first, middle, last);
-    sortHeap(first, middle);
+    heapSelect(first, middle, last, compareLess?);
+    sortHeap(first, middle, compareLess?);
 }
 

--- a/lib-clay/queues/queues.clay
+++ b/lib-clay/queues/queues.clay
@@ -9,7 +9,7 @@ alias VectorQueue[T] = Queue[Vector[T]];
 [S] overload Queue(forward seq: S) returned: Queue[S] {
     returned.seq <-- seq;
     try {
-        makeHeap(begin(returned.seq), end(returned.seq));
+        makeHeap(begin(returned.seq), end(returned.seq), lesser?);
     } catch (ex) {
         destroy(returned.seq);
         throw ex;
@@ -20,7 +20,7 @@ alias VectorQueue[T] = Queue[Vector[T]];
 overload Queue[S](forward seq: S2) returned: Queue[S] {
     returned.seq <-- S(seq);
     try {
-        makeHeap(begin(returned.seq), end(returned.seq));
+        makeHeap(begin(returned.seq), end(returned.seq), lesser?);
     } catch (ex) {
         destroy(returned.seq);
         throw ex;
@@ -47,13 +47,13 @@ overload Queue[S](forward ...values: A) returned: Queue[S] {
 queuePush(q: Queue[S], forward v_: T) {
     var v = v_;
     push(q.seq, v);
-    pushHeap(begin(q.seq), size(q.seq) - 1, 0, move(v));
+    pushHeap(begin(q.seq), size(q.seq) - 1, 0, move(v), lesser?);
 }
 
 [S]
 queuePop(q: Queue[S]) {
     var backi = end(q.seq) - 1;
-    popHeap(begin(q.seq), backi, backi);
+    popHeap(begin(q.seq), backi, backi, lesser?);
     return pop(q.seq);
 }
 

--- a/test/algorithms/sorting/test.clay
+++ b/test/algorithms/sorting/test.clay
@@ -1,0 +1,21 @@
+import test.*;
+import algorithms.*;
+
+main() = testMain(
+  TestSuite("sorting", [
+    TestCase("In ascending order", test => {
+      var baseSequence = [10, 9, 8, 1, 2, 7, 6, 2, 3, 4];
+      var sortedSequence = [1, 2, 2, 3, 4, 6, 7, 8, 9, 10];
+
+      sort(baseSequence);
+      expectEqual(test, "the sorted sequence", sortedSequence, baseSequence);
+    }),
+    TestCase("In descending order", test => {
+      var baseSequence = [10, 9, 8, 1, 2, 7, 6, 2, 3, 4];
+      var sortedSequence =  [10, 9, 8, 7, 6, 4, 3, 2, 2, 1];
+
+      sort(baseSequence, greater?);
+      expectEqual(test, "the sorted sequence", sortedSequence, baseSequence);
+    })
+  ])
+);

--- a/test/random/out.txt
+++ b/test/random/out.txt
@@ -4,6 +4,6 @@ Testing Random number generation:
   runs from two RNGs created consecutively: passed
   uniform integers should be in range: passed
   uniform integers should cover the whole range: passed
-  uniform floats should be in range: passed
--- Random number generation: 28 expectations passed; 0 failed (0 pending)
-Overall: 28 expectations passed; 0 failed (0 pending)
+  uniform doubles should be in range: passed
+-- Random number generation: 218 expectations passed; 0 failed (0 pending)
+Overall: 218 expectations passed; 0 failed (0 pending)


### PR DESCRIPTION
Largely mechanical change to the sorting API that allows one to specify a custom comparison operator which replaces the role of lesser? in sorting. 

This change should similarly be propagated to the queues API but I wasn't quite sure what the best approach there was, so I've simply left it for now - updated the code to always pass lesser? to the underlying heap operations.
