### PR TITLE
test externals.abi: fix for 64/32 bit differences

### DIFF
--- a/test/externals/abi/external_test.c
+++ b/test/externals/abi/external_test.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <complex.h>
+#include <inttypes.h>
 
 struct Struct1 {
     uint64_t a;
@@ -180,7 +181,7 @@ void c_complex_double(complex double x) {
 }
 
 void c_1(struct Struct1 x) {
-    printf("%llx\n", x.a);
+    printf("%" PRIx64 "\n", x.a);
 }
 
 void c_2(struct Struct2 x) {
@@ -196,19 +197,19 @@ void c_4(struct Struct4 x) {
 }
 
 void c_5(struct Struct5 x) {
-    printf("%x %x %llx\n", x.a, x.b, x.c);
+    printf("%x %x %" PRIx64 "\n", x.a, x.b, x.c);
 }
 
 void c_6(struct Struct6 x) {
-    printf("%x %llx\n", x.a, x.b);
+    printf("%x %" PRIx64 "\n", x.a, x.b);
 }
 
 void c_7(struct Struct7 x) {
-    printf("%x %llx %x\n", x.a, x.b, x.c);
+    printf("%x %" PRIx64 " %x\n", x.a, x.b, x.c);
 }
 
 void c_8(struct Struct8 x) {
-    printf("%llx %llx %llx\n", x.a, x.b, x.c);
+    printf("%" PRIx64 " %" PRIx64 " %" PRIx64 "\n", x.a, x.b, x.c);
 }
 
 void c_9(struct Struct9 x) {

--- a/test/externals/abi/run.py
+++ b/test/externals/abi/run.py
@@ -5,12 +5,13 @@ import os
 clayobj = argv[1]
 buildFlags = argv[2:]
 
-if platform == 'linux':
-    buildFlags += ['-lm']
+linkFlags = [];
+if platform == 'linux' or platform == 'linux2':
+    linkFlags += ['-lm']
 
 try:
     check_call(["clang", "-c", "-o", "temp-external_test.o", "external_test.c"] + buildFlags)
-    check_call(["clang", "-o", "temp.exe", "temp-external_test.o", clayobj] + buildFlags)
+    check_call(["clang", "-o", "temp.exe", "temp-external_test.o", clayobj] + linkFlags)
     check_call(["./temp.exe"])
 except CalledProcessError as ex:
     print "!! error code", ex.returncode

--- a/test/externals/abi/x86/external_test_x86.c
+++ b/test/externals/abi/x86/external_test_x86.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <complex.h>
 #include <emmintrin.h>
+#include <inttypes.h>
 
 struct Struct_x86_1 {
     long double a;
@@ -66,7 +67,7 @@ union Union_x86_13 {
 
 static void print_int_vector(__m128i v) {
     union { __m128i v; uint64_t fields[2]; } u = { v };
-    printf("<%llx %llx>\n", u.fields[0], u.fields[1]);
+    printf("<%" PRIx64 " %" PRIx64 ">\n", u.fields[0], u.fields[1]);
 }
 
 static void print_float_vector(__m128 v) {
@@ -150,7 +151,7 @@ void c_x86_10(union Union_x86_10 x, int tag) {
 void c_x86_11(union Union_x86_11 x, int tag) {
     switch (tag) {
     case 0:
-        printf("%llx\n", (uint64_t)x.a);
+        printf("%" PRIx64 "\n", (uint64_t)x.a);
         break;
     case 1:
         print_double_vector(x.b);

--- a/test/externals/abi/x86/run.py
+++ b/test/externals/abi/x86/run.py
@@ -5,12 +5,13 @@ import os
 clayobj = argv[1]
 buildFlags = argv[2:]
 
-if platform == 'linux':
-    buildFlags += ['-lm']
+linkFlags = [];
+if platform == 'linux' or platform == 'linux2':
+    linkFlags += ['-lm']
 
 try:
     check_call(["clang", "-c", "-o", "temp-external_test_x86.o", "external_test_x86.c"] + buildFlags)
-    check_call(["clang", "-o", "temp.exe", "temp-external_test_x86.o", clayobj] + buildFlags)
+    check_call(["clang", "-o", "temp.exe", "temp-external_test_x86.o", clayobj] + linkFlags)
     check_call(["./temp.exe"])
 except CalledProcessError as ex:
     print "!! error code", ex.returncode


### PR DESCRIPTION
Not sure if you like the printf macros, but it's a non-hacky cross-platform solution :) Also python's `sys.platform` is `linux2` on my system (even though I'm on linux version 3.1?).
