### PR TITLE
fix compilation of external test on linux

### DIFF
--- a/test/externals/abi/common/external_test.cpp
+++ b/test/externals/abi/common/external_test.cpp
@@ -4,6 +4,7 @@
 #ifdef _MSC_VER
 # define PRIx64 "I64x"
 #else
+# define __STDC_FORMAT_MACROS
 # include <inttypes.h>
 #endif
 


### PR DESCRIPTION
apparently in C++ a macro has to be defined for the printf macros to be
defined
