### PR TITLE
add the <<= operator

### DIFF
--- a/compiler/src/lexer.cpp
+++ b/compiler/src/lexer.cpp
@@ -128,7 +128,7 @@ static void initKeywords() {
          "switch", "case", "break", "continue", "for", "in",
          "true", "false", "try", "catch", "throw",
          "finally", "onerror",
-         "eval",
+         "eval", "with",
          "__FILE__", "__LINE__", "__COLUMN__", "__ARG__", NULL};
     keywords = new std::set<string>();
     for (const char **p = s; *p; ++p)

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -1191,6 +1191,68 @@ static bool localBinding(StatementPtr &x) {
     return true;
 }
 
+
+static bool blockItems(vector<StatementPtr> &stmts);
+static bool monad(StatementPtr &x) {
+    LocationPtr startLocation = currentLocation();
+
+    if (!keyword("with")) return false;
+
+    int p = save();
+    bool hasBoundValues = false;
+
+    vector<IdentifierPtr> identifier;
+    if (identifierList(identifier) && keyword("in")) {
+        hasBoundValues = true;
+    } else {
+        restore(p);
+    }
+    LocationPtr location = currentLocation();
+
+    ExprListPtr inExpressions = NULL;
+    if (!expressionList(inExpressions)) return false;
+    if (!symbol(";")) return false;
+
+    //consume the rest of the block into a lambda
+    BlockPtr b = new Block();
+    if (!blockItems(b->statements)) return false;
+
+
+    vector<FormalArgPtr> formalArgs;
+    if (hasBoundValues) {
+        for(int i = 0; i < identifier.size(); i++) {
+            formalArgs.push_back(new FormalArg(identifier.at(i), NULL, TEMPNESS_DONTCARE));
+        }
+    }
+
+    FormalArgPtr formalVarArg = NULL;
+    bool captureByRef = false;
+
+    ExprPtr la = new Lambda(captureByRef, formalArgs, formalVarArg, b.ptr());
+    la->location = location;
+
+    //append the lambda to the arguments for yield
+    inExpressions->add(la);
+
+
+    //form the return yield expression
+
+    ExprListPtr rexprs = new ExprList();
+
+    ExprPtr yieldCall = new Call(NULL, inExpressions, new ExprList());
+    ExprPtr yieldName = new NameRef(new Identifier("Monad"));
+
+    setSuffixBase(yieldCall.ptr(), yieldName);
+
+    rexprs->add(yieldCall);
+
+    ReturnPtr r = new Return(RETURN_VALUE, rexprs);
+
+    x = r.ptr();
+    x->location = location;
+    return true;
+}
+
 static bool blockItem(StatementPtr &x) {
     int p = save();
     if (labelDef(x)) return true;
@@ -1203,6 +1265,11 @@ static bool blockItems(vector<StatementPtr> &stmts) {
     while (true) {
         int p = save();
         StatementPtr z;
+        if (monad(z)) {
+            stmts.push_back(z);
+            break;
+        }
+        restore(p);
         if (!blockItem(z)) {
             restore(p);
             break;


### PR DESCRIPTION
the <<= operator allows async unboxing in the library

"var a <<= f;"  expands to "return yield(f, (a)->
and the rest of the current block is put into the lambda body

inspired by C#'s  await/async
kudos to Joe Groff
