### PR TITLE
Fix building on Fedora

### DIFF
--- a/compiler/src/CMakeLists.txt
+++ b/compiler/src/CMakeLists.txt
@@ -66,7 +66,7 @@ add_executable(clay ${SOURCES})
 set_target_properties(clay PROPERTIES COMPILE_FLAGS "${CLAY_CXXFLAGS}")
 
 if (UNIX)
-    set_target_properties(clay PROPERTIES LINK_FLAGS ${LLVM_LDFLAGS})
+    set_target_properties(clay PROPERTIES LINK_FLAGS "${LLVM_LDFLAGS}")
 endif(UNIX)
 
 install(TARGETS clay RUNTIME DESTINATION bin)


### PR DESCRIPTION
I'm helping @CodeBlock make a Clay package for Fedora, and he ran into this problem from `cmake`:

```
CMake Error at compiler/src/CMakeLists.txt:69 (set_target_properties):
  set_target_properties called with incorrect number of arguments.
```

This commit fixes it.
