### PR TITLE
Fixed syntax errors in named return syntax in lib-clay/twohash

### DIFF
--- a/lib-clay/twohash/implementation/implementation.clay
+++ b/lib-clay/twohash/implementation/implementation.clay
@@ -91,7 +91,7 @@ overload assign(ref to:TwoHash[E], ref from:TwoHash[E]) {
 }
 
 [B]
-overload Table[B](ln2_size: Int) returned:Table[B]
+overload Table[B](ln2_size: Int) --> returned:Table[B]
 {
     var size = bitshl(1, ln2_size);
     returned.ln2_size <-- ln2_size;
@@ -105,7 +105,7 @@ overload Table[B](ln2_size: Int) returned:Table[B]
 }
 
 [B]
-overload Table[B](x: Table[B]) returned:Table[B]
+overload Table[B](x: Table[B]) --> returned:Table[B]
 {
     var size = bitshl(1, x.ln2_size);
     returned.ln2_size <-- x.ln2_size;
@@ -125,7 +125,7 @@ overload initialize(b: Bucket[E])
 }
 
 [E]
-overload Bucket[E](b: Bucket[E]) returned:Bucket[E]
+overload Bucket[E](b: Bucket[E]) --> returned:Bucket[E]
 {
     returned.hashBytes <-- b.hashBytes;
     for (i in range(16))

--- a/lib-clay/twohash/twohash.clay
+++ b/lib-clay/twohash/twohash.clay
@@ -252,7 +252,7 @@ overload entryHash(entry: E) = largeHash(entry.key);
 //
 
 [K]
-overload SetVector[K]() set: SetVector[K]
+overload SetVector[K]() --> set: SetVector[K]
 {
     set.data <-- TwoHash[SetVectorEntry[K]]();
     set.sentinel = allocateRawMemory(SetVectorEntry[K], 1);
@@ -269,7 +269,7 @@ overload destroy(set: SetVector[K])
 }
 
 [K]
-overload SetVectorEntry[K](a: SetVector[K], key: K) entry: SetVectorEntry[K]
+overload SetVectorEntry[K](a: SetVector[K], key: K) --> entry: SetVectorEntry[K]
 {
     ref sentinel = a.sentinel;
     entry.key <-- move(key);
@@ -295,7 +295,7 @@ overload resetUnsafe(a: SetVectorEntry[K])
 }
 
 [K]
-overload moveEntry(src: SetVectorEntry[K], th) entry: SetVectorEntry[K]
+overload moveEntry(src: SetVectorEntry[K], th) --> entry: SetVectorEntry[K]
 {
     entry <-- move(src);
     entry.prev^.next = &entry;


### PR DESCRIPTION
I'm guessing this may have been an older syntax for named returns. Am I right? Also, found the following 6 more similar issues by grepping.

```
trss$ grep -PInr --include=*.clay --exclude=*generated* \(?:\\w\|\\]\)\ *[\(].*[\)]\ *\(?:\\w\|[.]\)+: ~/Projects/Clay/jckarter/clay/ | more

Left over issues:-
lib-clay/externals/externals.clay:5:// impl_fn(a:A, b:B, ..) x:X, y:Y, ..
lib-clay/externals/externals.clay:8:// fn(a:A, b:B, ..) x:X, y:Y, ..
test/modules/imports/ambiguous3/a.clay:1:external ("a_foo") foo:Int;
test/modules/imports/ambiguous3/b.clay:1:external ("b_foo") foo:Int;
test/sequences/ranges/main.clay:33:    println("sliced(v,1,0) size: ", size(sliced(v,1,0)));
tools/fix/v0_0.clay:432://   foo() returned:Int {} // named return values

Fixed issues:-
lib-clay/twohash/implementation/implementation.clay:94:overload Table[B](ln2_size: Int) returned:Table[B]
lib-clay/twohash/implementation/implementation.clay:108:overload Table[B](x: Table[B]) returned:Table[B]
lib-clay/twohash/implementation/implementation.clay:128:overload Bucket[E](b: Bucket[E]) returned:Bucket[E]
lib-clay/twohash/twohash.clay:255:overload SetVector[K]() set: SetVector[K]
lib-clay/twohash/twohash.clay:272:overload SetVectorEntry[K](a: SetVector[K], key: K) entry: SetVectorEntry[K]
lib-clay/twohash/twohash.clay:298:overload moveEntry(src: SetVectorEntry[K], th) entry: SetVectorEntry[K]
```
