### PR TITLE
use 'repr' in test framework in expectEqual and similar functions

### DIFF
--- a/lib-clay/test/test.clay
+++ b/lib-clay/test/test.clay
@@ -6,6 +6,7 @@ import io.files.*;
 import strings.*;
 import lambdas.*;
 import vectors.*;
+import printer.formatter.(repr);
 
 record TestStatus (
     passed: UInt,
@@ -157,7 +158,7 @@ expectEqual(test: TestStatus, name, expected, result) {
         test,
         expected == result,
         () => {
-            printFailure(name, " is expected to equal ", expected, " but is ", result);
+            printFailure(name, " is expected to equal ", repr(expected), " but is ", repr(result));
         }
     );
 }
@@ -167,7 +168,7 @@ expectNotEqual(test: TestStatus, name, expected, result) {
         test,
         expected != result,
         () => {
-            printFailure(name, " is expected not to equal ", expected, " but is ", result);
+            printFailure(name, " is expected not to equal ", repr(expected), " but is ", repr(result));
         }
     );
 }
@@ -184,9 +185,9 @@ expectEqualValues(test: TestStatus, name, expectedTuple, ..results) {
         expectedResults?(expectedTuple, resultsTuple),
         () => {
             printFailure(name, " are expected to equal:");
-            printFailure(TEST_CASE_INDENT, ..weaveValues(", ", ..unpack(expectedTuple)));
+            printFailure(TEST_CASE_INDENT, ..weaveValues(", ", ..mapValues(repr, ..unpack(expectedTuple))));
             printFailure("but are:");
-            printFailure(TEST_CASE_INDENT, ..weaveValues(", ", ..unpack(resultsTuple)));
+            printFailure(TEST_CASE_INDENT, ..weaveValues(", ", ..mapValues(repr, ..unpack(resultsTuple))));
         }
     );
 }
@@ -227,10 +228,10 @@ expectIterator(test: TestStatus, name, iter:I, ..expected) {
         () => {
             printFailure(name, " is expected to contain:");
             for (expectedX in expectedV)
-                printFailure(TEST_CASE_INDENT, expectedX);
+                printFailure(TEST_CASE_INDENT, repr(expectedX));
             printFailure("but contains:");
             for (resultX in resultV)
-                printFailure(TEST_CASE_INDENT, resultX);
+                printFailure(TEST_CASE_INDENT, repr(resultX));
         }
     );
 }

--- a/test/test/1/out.txt
+++ b/test/test/1/out.txt
@@ -5,17 +5,17 @@ Testing test test suite:
 
     falsehood is expected to be false but isn't
 
-    unity is expected to equal 1 but is 3
+    unity is expected to equal 1i but is 3i
 
     unity and trinity are expected to equal:
-      1, 3
+      1i, 3i
     but are:
-      1, 2
+      1i, 2i
 
     unity and trinity are expected to equal:
-      1, 3
+      1i, 3i
     but are:
-      1, 2, 3
+      1i, 2i, 3i
 
     + isn't callable with the expected argument types:
       Int32, Vector[Char]
@@ -24,56 +24,56 @@ Testing test test suite:
       Vector[Char], Vector[Char]
 
     primes iterator is expected to contain:
-      1
-      3
-      5
-      7
-      11
+      1i
+      3i
+      5i
+      7i
+      11i
     but contains:
-      2
-      3
-      5
-      7
-      11
+      2i
+      3i
+      5i
+      7i
+      11i
 
     primes iterator is expected to contain:
-      2
-      3
-      5
-      7
-      9
+      2i
+      3i
+      5i
+      7i
+      9i
     but contains:
-      2
-      3
-      5
-      7
-      11
+      2i
+      3i
+      5i
+      7i
+      11i
 
     primes iterator is expected to contain:
-      2
-      3
-      5
-      7
+      2i
+      3i
+      5i
+      7i
     but contains:
-      2
-      3
-      5
-      7
-      11
+      2i
+      3i
+      5i
+      7i
+      11i
 
     primes iterator is expected to contain:
-      2
-      3
-      5
-      7
-      11
-      13
+      2i
+      3i
+      5i
+      7i
+      11i
+      13i
     but contains:
-      2
-      3
-      5
-      7
-      11
+      2i
+      3i
+      5i
+      7i
+      11i
 
     throws int is expected to throw exception of type Int32 but throws 7
 

--- a/test/test/repr/main.clay
+++ b/test/test/repr/main.clay
@@ -1,0 +1,24 @@
+// test uses repr to print values that are not equal
+
+import test.*;
+import vectors.*;
+
+main() = testMain(
+    TestSuite(
+        "test uses repr to print values", array(
+            TestCase("in expectEqual", test => {
+                expectEqual(test, "newline (not really)", "\n", "\t");
+            }),
+            TestCase("in expectNotEqual", test => {
+                expectNotEqual(test, "newline (not really)", "\n", "\n");
+            }),
+            TestCase("in expectEqualValues", test => {
+                expectEqualValues(test, "something (not really)", ['\r', "x\t"], '\x12', "x\t");
+            }),
+            TestCase("in expectIterator and expectSequence", test => {
+                var vs = Vector[UInt32](1u, 17u);
+                expectIterator(test, "values (not really)", iterator(vs), 4u);
+                expectSequence(test, "values (not really)", vs, 12u);
+            }),
+        ),
+    ));

--- a/test/test/repr/out.txt
+++ b/test/test/repr/out.txt
@@ -1,0 +1,29 @@
+Testing test uses repr to print values:
+  in expectEqual:
+    newline (not really) is expected to equal "\n" but is "\t"
+    -- FAILED
+  in expectNotEqual:
+    newline (not really) is expected not to equal "\n" but is "\n"
+    -- FAILED
+  in expectEqualValues:
+    something (not really) are expected to equal:
+      '\r', "x\t"
+    but are:
+      '\x12', "x\t"
+    -- FAILED
+  in expectIterator and expectSequence:
+    values (not really) is expected to contain:
+      4u
+    but contains:
+      1u
+      17u
+
+    values (not really) is expected to contain:
+      12u
+    but contains:
+      1u
+      17u
+    -- FAILED
+-- test uses repr to print values: 0 expectations passed; 5 failed (0 pending)
+Overall: 0 expectations passed; 5 failed (0 pending)
+TESTS FAILED


### PR DESCRIPTION
problem with current behavior is that expectEquals produces weird output when
compared object contains control characters, as in this example:

```
expectEqual(test, "newline", "\n\t", actual);
```
