### PR TITLE
Protocols

### DIFF
--- a/lib-clay/commandline/options/parser.clay
+++ b/lib-clay/commandline/options/parser.clay
@@ -119,7 +119,7 @@ private seekToken(pr, key, scanner){
     addOption(pr, key, nextToken);
   } else {
     missingValue(pr, key);
-    push(scanner, nextToken);
+    pushback(scanner, nextToken);
   }
 }
 

--- a/lib-clay/commandline/options/util.clay
+++ b/lib-clay/commandline/options/util.clay
@@ -10,7 +10,7 @@ record PushbackIterator[S, T](
   else return getMaybeValue(nextValue(it.base));
 }
 
-[S, T] overload push(it : PushbackIterator[S, T], x : S){ push(it.pending, x); }
+[S, T] pushback(it : PushbackIterator[S, T], x : S){ push(it.pending, x); }
 
 [T] withPushback(it : T) : PushbackIterator[IteratorTargetType(T), T] {
   alias S = IteratorTargetType(T);

--- a/lib-clay/core/coordinates/coordinates.clay
+++ b/lib-clay/core/coordinates/coordinates.clay
@@ -28,12 +28,12 @@ forceinline overload subtract(c1:ValueCoordinate[T], c2:ValueCoordinate[T]) =
     c1.value - c2.value;
 
 [T]
-forceinline overload inc(c:ValueCoordinate[T]) {
+forceinline overload inc(ref c:ValueCoordinate[T]) {
     inc(c.value);
 }
 
 [T]
-forceinline overload dec(c:ValueCoordinate[T]) {
+forceinline overload dec(ref c:ValueCoordinate[T]) {
     dec(c.value);
 }
 
@@ -59,12 +59,12 @@ forceinline overload subtract(c1:ValueReverseCoordinate[T], c2:ValueReverseCoord
     c2.value - c1.value;
 
 [T]
-forceinline overload inc(c:ValueReverseCoordinate[T]) {
+forceinline overload inc(ref c:ValueReverseCoordinate[T]) {
     dec(c.value);
 }
 
 [T]
-forceinline overload dec(c:ValueReverseCoordinate[T]) {
+forceinline overload dec(ref c:ValueReverseCoordinate[T]) {
     inc(c.value);
 }
 
@@ -95,11 +95,11 @@ forceinline overload subtract(c1:ReverseCoordinate[T], c2:ReverseCoordinate[T]) 
     c2.coord - c1.coord;
 
 [T]
-forceinline overload inc(c:ReverseCoordinate[T]) {
+forceinline overload inc(ref c:ReverseCoordinate[T]) {
     dec(c.coord);
 }
 
 [T]
-forceinline overload dec(c:ReverseCoordinate[T]) {
+forceinline overload dec(ref c:ReverseCoordinate[T]) {
     inc(c.coord);
 }

--- a/lib-clay/core/numbers/numbers.clay
+++ b/lib-clay/core/numbers/numbers.clay
@@ -317,16 +317,16 @@ forceinline overload (-)(a:A) = numericNegate(a);
 
 /// @section  inc, dec 
 
-forceinline overload inc(..a) { eachValue(inc, ..a); }
-forceinline overload dec(..a) { eachValue(dec, ..a); }
+forceinline overload inc(ref ..a) { eachValue(inc, ..a); }
+forceinline overload dec(ref ..a) { eachValue(dec, ..a); }
 
 [A when Numeric?(A)]
-forceinline overload inc(a:A) {
+forceinline overload inc(ref a:A) {
     a +: A(1);
 }
 
 [A when Numeric?(A)]
-forceinline overload dec(a:A) {
+forceinline overload dec(ref a:A) {
     a -: A(1);
 }
 

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -39,8 +39,9 @@ public import __operators__.(
 define inc(ref ..a) :;
 define dec(ref ..a) :;
 
-define moveUnsafe;
-define resetUnsafe;
+[A]
+define moveUnsafe(a:A) : A;
+define resetUnsafe(a) :;
 
 
 

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -89,34 +89,66 @@ alias overload hasValue?(iter, coord) = hasValue?(coord);
 
 /// @section  reverse iteration 
 
-define reverseIterator;
+[S when Sequence?(S)]
+define reverseIterator(s:S);
 
 
 
 /// @section  sequence protocol 
 
-define size;
+// defined for collections
+define size(s): SizeT;
 
-define begin;
-define end;
 
-define front;
-define back;
+[S when Sequence?(S)]
+define begin(s:S);
 
-define push;
-define pop;
-define clear;
-define insert;
+[S when Sequence?(S)]
+define end(s:S);
+
+
+[S when Sequence?(S)]
+define front(s:S);
+
+[S when Sequence?(S)]
+define back(s:S);
+
+
+[S when Sequence?(S)]
+define push(s:S, ..vs) :;
+
+[S when Sequence?(S)]
+define pop(s:S);
+
+// defined for collections
+define clear(s) :;
+
+[S when Sequence?(S)]
+define insert(s:S, coord, v) :;
+
+// defined for collections
 define remove;
-define reserve;
-define resize;
-define resizeUnsafe;
 
-define pushFront;
-define popFront;
+[S, I when Sequence?(S) and Integer?(I)]
+define reserve(s:S, n:I) :;
+
+[S, I when Sequence?(S) and Integer?(I)]
+define resize(s:S, n:I) :;
+
+[S, I when Sequence?(S) and Integer?(I)]
+define resizeUnsafe(s:S, n:I) :;
+
+
+[S when Sequence?(S)]
+define pushFront(s:S, v) :;
+
+[S when Sequence?(S)]
+define popFront(s:S);
+
 
 // defined for statically sized sequences like Array[T,n]
-define StaticSize;
+[S]
+define StaticSize(#S);
 
 
 
@@ -157,9 +189,11 @@ overload multiValued?(x) = false;
 // 'index' and 'size' are available for mappings
 // 'remove' is available
 
-define lookup; // get pointer to element, null if not available
-define put;
-define items; // iterate over all items
+// get pointer to element, null if not available
+define lookup(map, key);
+define put(map, key, value) :;
+// iterate over all items
+define items(map);
 
 forceinline contains?(map, key) = not null?(lookup(map, key));
 

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -36,8 +36,8 @@ public import __operators__.(
 );
 
 
-define inc;
-define dec;
+define inc(ref ..a) :;
+define dec(ref ..a) :;
 
 define moveUnsafe;
 define resetUnsafe;

--- a/lib-clay/core/pointers/pointers.clay
+++ b/lib-clay/core/pointers/pointers.clay
@@ -71,12 +71,12 @@ forceinline overload subtract(a:Pointer[T], b:Pointer[T]) {
 }
 
 [T]
-forceinline overload inc(a:Pointer[T]) {
+forceinline overload inc(ref a:Pointer[T]) {
     a +: 1;
 }
 
 [T]
-forceinline overload dec(a:Pointer[T]) {
+forceinline overload dec(ref a:Pointer[T]) {
     a -: 1;
 }
 

--- a/lib-clay/deques/deques.clay
+++ b/lib-clay/deques/deques.clay
@@ -29,7 +29,7 @@ record DequeCoordinate[T] (
 [T] overload DequeCoordinate[T](current: Pointer[T], node: Pointer[Pointer[T]])
     = DequeCoordinate[T](current, nodeBegin(node), nodeEnd(node), node);
 
-[T] overload inc(i: DequeCoordinate[T]) {
+[T] overload inc(ref i: DequeCoordinate[T]) {
     inc(i.current);
     if(i.current == i.last) {
         setNode(i, i.node + 1);
@@ -37,7 +37,7 @@ record DequeCoordinate[T] (
     }
 }
 
-[T] overload dec(i: DequeCoordinate[T]) {
+[T] overload dec(ref i: DequeCoordinate[T]) {
     if (i.current == i.first) {
         setNode(i, i.node - 1);
         i.current = i.last;

--- a/lib-clay/paged/allocator/allocator.clay
+++ b/lib-clay/paged/allocator/allocator.clay
@@ -210,12 +210,12 @@ overload subtract(a:PagedPointer[T], b:PagedPointer[T]) {
 }
 
 [T]
-overload inc(p:PagedPointer[T]) {
+overload inc(ref p:PagedPointer[T]) {
     p +: 1;
 }
 
 [T]
-overload dec(p:PagedPointer[T]) {
+overload dec(ref p:PagedPointer[T]) {
     p -: 1;
 }
 

--- a/lib-clay/sequences/lazy/grouped/grouped.clay
+++ b/lib-clay/sequences/lazy/grouped/grouped.clay
@@ -99,7 +99,7 @@ overload end(group: Group[S]) {
 }
 
 [C]
-overload inc(c: FGroupCoordinate[C]) {
+overload inc(ref c: FGroupCoordinate[C]) {
     if (c.endCoord == c.sequenceEndCoord)
         c.beginCoord = c.endCoord;
     else
@@ -110,7 +110,7 @@ overload inc(c: FGroupCoordinate[C]) {
 }
 
 [C]
-overload dec(c: FGroupCoordinate[C]) {
+overload dec(ref c: FGroupCoordinate[C]) {
     if (c.beginCoord == c.sequenceEndCoord)
         for (i in range(group.groupSize))
             dec(c.beginCoord);
@@ -182,12 +182,12 @@ overload subtract(i: RAGroupCoordinate[C], j: RAGroupCoordinate[C])
     = PtrInt(i.coord - j.coord) \ PtrInt(i.groupSize);
 
 [C]
-overload inc(i: RAGroupCoordinate[C]) {
+overload inc(ref i: RAGroupCoordinate[C]) {
     i.coord +: i.groupSize;
 }
 
 [C]
-overload dec(i: RAGroupCoordinate[C]) {
+overload dec(ref i: RAGroupCoordinate[C]) {
     i.coord -: i.groupSize;
 }
 

--- a/lib-clay/sequences/lazy/mapped/mapped.clay
+++ b/lib-clay/sequences/lazy/mapped/mapped.clay
@@ -89,12 +89,12 @@ forceinline overload subtract(x1:MappedCoordinate[F, COORD],
     x1.coord - x2.coord;
 
 [F, COORD when CallDefined?(inc, COORD)]
-forceinline overload inc(x:MappedCoordinate[F, COORD]) {
+forceinline overload inc(ref x:MappedCoordinate[F, COORD]) {
     inc(x.coord);
 }
 
 [F, COORD when CallDefined?(dec, COORD)]
-forceinline overload dec(x:MappedCoordinate[F, COORD]) {
+forceinline overload dec(ref x:MappedCoordinate[F, COORD]) {
     dec(x.coord);
 }
 

--- a/lib-clay/twohash/implementation/implementation.clay
+++ b/lib-clay/twohash/implementation/implementation.clay
@@ -86,7 +86,7 @@ overload TwoHash[E]()
 [B]
 overload Table[B](ln2_size: Int) 
 {
-    var size = bitshl(1, ln2_size);
+    var size = bitshl(SizeT(1), ln2_size);
     var ptr = allocateRawMemoryAligned(B, size, 16);
     initializeMemory(ptr, ptr+size);
     return Table[B](ptr, ln2_size);
@@ -239,9 +239,9 @@ freeEntry(th: TwoHash[E], pEntry: Pointer[E])
 record TwoHashEntries[E, F]
 (
     data: Pointer[TwoHash[E]],
-    i: Int,
-    j: Int,
-    entryMask: Int,
+    i: SizeT,
+    j: SizeT,
+    entryMask: SizeT,
 );
 
 record TwoHashEntry[E, F]
@@ -265,7 +265,7 @@ overload nextValue(x: TwoHashEntries[E, F])
 {
     if (x.entryMask != 0) {
         var k = lowBit(x.entryMask);
-        x.entryMask = x.entryMask - bitshl(1, k);
+        x.entryMask = x.entryMask - bitshl(SizeT(1), k);
         ref e = x.data^.tables[x.i][x.j].entries[k];
         if (x.entryMask == 0)
         {
@@ -303,7 +303,7 @@ refillMask(x: TwoHashEntries[E, F])
         for (k in range(16))
         {
             if (th.tables[x.i][x.j].hashBytes[k] != 255uss)
-                x.entryMask = bitor(x.entryMask, bitshl(1, k));
+                x.entryMask = bitor(x.entryMask, bitshl(SizeT(1), k));
         }
         if (x.entryMask != 0) return;
         nextBucket(x);
@@ -318,7 +318,7 @@ refillMask(x: TwoHashEntries[E, F])
 overload iterator(t: Table[B]) = CoordinateRange(begin(t), end(t));
 
 [B]
-overload size(t: Table[B]) = bitshl(1, t.ln2_size);
+overload size(t: Table[B]) = bitshl(SizeT(1), t.ln2_size);
 
 [B]
 overload index(t: Table[B], idx) = ref t.ptr[idx];

--- a/lib-clay/twohash/implementation/implementation.clay
+++ b/lib-clay/twohash/implementation/implementation.clay
@@ -315,6 +315,9 @@ refillMask(x: TwoHashEntries[E, F])
 //
 
 [B]
+overload iterator(t: Table[B]) = CoordinateRange(begin(t), end(t));
+
+[B]
 overload size(t: Table[B]) = bitshl(1, t.ln2_size);
 
 [B]


### PR DESCRIPTION
Add "define" function signatures to core.operators.

I think this makes code easier to read and to maintain.

As part of this refactoring other parts of standard library were tweaked:
- twohash implementation was tweaked: size type changed from Int to SizeT
- twohash Table record made Sequence to overload begin function
- PushbackIterator push function renamed to pushback, because PushbackIterator is not Sequence
