### PR TITLE
filterValues function

### DIFF
--- a/lib-clay/core/values/values.clay
+++ b/lib-clay/core/values/values.clay
@@ -21,6 +21,17 @@ private define _mapIndexedValues;
 
 mapIndexedValues(fn, forward ..values) = forward .._mapIndexedValues(fn, #0, ..values);
 
+// filter values using given predicate
+// unlike most other functions, all parameters must be static values
+[Fn]
+define filterValues(#Fn, ..xs);
+[Fn, First when Fn(First)]
+overload filterValues(#Fn, #First, ..xs) = #First, ..filterValues(#Fn, ..xs);
+[Fn, First when not Fn(First)]
+overload filterValues(#Fn, #First, ..xs) = ..filterValues(#Fn, ..xs);
+[Fn]
+overload filterValues(#Fn) = ;
+
 define foldValues;
 forceinline overload foldValues(fn, forward x, forward ..xs)
     = fn(x, foldValues(fn, ..xs));

--- a/test/values/1/test.clay
+++ b/test/values/1/test.clay
@@ -120,6 +120,24 @@ main() = testMain(
                 )]
             );
         }),
+        TestCase("filterValues", test => {
+            expectEqual(test, "filterValues 2 from 4",
+                [#2, #4],
+                [..filterValues(even?, #1, #2, #3, #4)]
+            );
+            expectEqual(test, "filterValues 0 from 2",
+                [],
+                [..filterValues(even?, #1, #3)]
+            );
+            expectEqual(test, "filterValues 2 from 2",
+                [#2, #6],
+                [..filterValues(even?, #2, #6)]
+            );
+            expectEqual(test, "filterValues 0 from 0",
+                [],
+                [..filterValues(even?)]
+            );
+        }),
         TestCase("assocValue", test => {
             expectEqual(test, "assocValue? first",
                 true,


### PR DESCRIPTION
unlike mapValue, filterValues parameters must be static values
