### PR TITLE
use checked cast when converting to Char and to UniChar

### DIFF
--- a/lib-clay/core/characters/characters.clay
+++ b/lib-clay/core/characters/characters.clay
@@ -10,18 +10,27 @@ Character?(x) = false;
 overload Character?(#Char) = true;
 overload Character?(#UniChar) = true;
 
-[I when Integer?(I)]
+// signed integer must be in range -128..128, otherwise this operation fails
+[I when SignedInteger?(I)]
 forceinline overload Char(c:I) --> returned:Char {
-    returned.code = wrapCast(Int8, c);
+    returned.code = Int8(c);
+}
+
+// unsigned integer must be in range 0..256, otherwise this operation fails
+[I when UnsignedInteger?(I)]
+forceinline overload Char(c:I) --> returned:Char {
+    returned.code = wrapCast(Int8, UInt8(c));
 }
 
 [I when Integer?(I)]
 forceinline overload UniChar(c:I) --> returned:UniChar {
-    returned.code = wrapCast(UInt32, c);
+    returned.code = UInt32(c);
 }
 
+// this operation fails if character is not in ASCII range
 forceinline overload UniChar(c:Char) = UniChar(c.code);
-forceinline overload Char(c:UniChar) = Char(c.code);
+// this operation fails if character is not in ASCII range
+forceinline overload Char(c:UniChar) = Char(Int8(c.code));
 
 [I when Integer?(I)]
 forceinline overload I(c:Char) = wrapCast(I, c.code);

--- a/test/characters/1/test.clay
+++ b/test/characters/1/test.clay
@@ -39,5 +39,17 @@ main() = testMain(
             expectFalse(test, "< (==)", UniChar('a') < UniChar('a'));
             expectFalse(test, "<",      UniChar('b') < UniChar('a'));
         }),
+        TestCase("conversion between Char, UniChar and integers", test => {
+            // only successful conversions are tested, because
+            // unsuccessful conversions crash process
+
+            expectEqual(test, "UniChar(Char(10))", UniChar(10), UniChar(Char(10)));
+            expectEqual(test, "Char(UniChar(20))", Char(20), Char(UniChar(20)));
+
+            expectEqual(test, "Char(250u)", Char(-6), Char(250u));
+            expectEqual(test, "Char(-6)", Char(-6), Char(-6));
+            
+            expectEqual(test, "Unichar(30000)", UniChar(30000), UniChar(30000));
+        }),
     )));
 


### PR DESCRIPTION
Before this commit

```
UniChar(Char(-1))
```

resulted in UniChar(4294967295). This is definitely not what developer
wants.  After this commit UniChar(Char(-1)) is integer overflow
error, and that's correct, because there is no single way to represent
non-ASCII Char values as Unicode characters.

And vice versa, before this commit

```
Char(UniChar(10000))
```

resulted in Char that does not represent original UniChar, so this
operation should also be integer overflow.

However, 8bit characters are often represented as UInt32 values in
range 0..256. For that case, Char(I) now has two overloads: for
signed integer and for unsigned integer parameter.
