### PR TITLE
fix == of sequences

### DIFF
--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -578,7 +578,7 @@ overload equals?(a:A, b:B) {
             return false;
         if (not iv?)
             return true;
-        if (getValue(i) != getValue(j))
+        if (getValue(iv) != getValue(jv))
             return false;
     }
 }

--- a/test/sequences/operators/test.clay
+++ b/test/sequences/operators/test.clay
@@ -1,0 +1,21 @@
+import test.*;
+
+record MySequenceWithoutSize ();
+record MyAnotherSequenceWithoutSize ();
+
+record DummyIterator ();
+
+overload iterator(s: MySequenceWithoutSize) = DummyIterator();
+overload iterator(s: MyAnotherSequenceWithoutSize) = DummyIterator();
+
+overload nextValue(iter: DummyIterator): Maybe[Int] = nothing(Int);
+
+testEqualsOnSequencesWithoutSize(test) {
+    expectEqual(test, "==", MySequenceWithoutSize(), MyAnotherSequenceWithoutSize());
+}
+
+main() = testMain(
+    TestSuite("sequence operators", array(
+        TestCase("== on sequences without size", testEqualsOnSequencesWithoutSize),
+    )));
+


### PR DESCRIPTION
getValue must be called on nextValue results, not on iterators

This error wasn't spotted before because fixed code is called only on sequences that are not sized sequences.
