### PR TITLE
numeric type utils

### DIFF
--- a/lib-clay/core/numbers/numbers.clay
+++ b/lib-clay/core/numbers/numbers.clay
@@ -30,6 +30,40 @@ IntegerAvailable?(#I) =
     TypeSize(I) <= TypeSize(Int64) or (CPU == X86_64 and OSFamily == Unix);
 
 
+/// builtin integer types
+BuiltinIntegerTypes() = Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128;
+
+
+/// get signed integer type by type size
+[S]
+define SignedIntegerOfSize(#S);
+
+/// get unsigned integer type by type size
+[S]
+define UnsignedIntegerOfSize(#S);
+
+overload SignedIntegerOfSize(#1) = Int8;
+overload SignedIntegerOfSize(#2) = Int16;
+overload SignedIntegerOfSize(#4) = Int32;
+overload SignedIntegerOfSize(#8) = Int64;
+overload SignedIntegerOfSize(#16) = Int128;
+
+overload UnsignedIntegerOfSize(#1) = UInt8;
+overload UnsignedIntegerOfSize(#2) = UInt16;
+overload UnsignedIntegerOfSize(#4) = UInt32;
+overload UnsignedIntegerOfSize(#8) = UInt64;
+overload UnsignedIntegerOfSize(#16) = UInt128;
+
+
+/// for integer type return signed integer of same type
+[I when Integer?(I)]
+SignedInteger(#I) = SignedIntegerOfSize(#Int(TypeSize(I)));
+
+/// for integer type return unsigned integer of same type
+[I when Integer?(I)]
+UnsignedInteger(#I) = UnsignedIntegerOfSize(#Int(TypeSize(I)));
+
+
 [T] ByteSizedInteger?(#T) = false;
 overload ByteSizedInteger?(#Int8) = true;
 overload ByteSizedInteger?(#UInt8) = true;
@@ -40,11 +74,21 @@ overload Float?(#Float64) = true;
 overload Float?(#Float80) = true;
 [A, B] overload Float?(#A, #B) = Float?(A) and Float?(B);
 
+
+/// builtin float types
+BuiltinFloatTypes() = Float32, Float64, Float80;
+
+
 [T] Imaginary?(#T) = false;
 overload Imaginary?(#Imag32) = true;
 overload Imaginary?(#Imag64) = true;
 overload Imaginary?(#Imag80) = true;
 [A, B] overload Imaginary?(#A, #B) = Imaginary?(A) and Imaginary?(B);
+
+
+/// builtin imaginary types
+BuiltinImaginaryTypes() = Imag32, Imag64, Imag80;
+
 
 [T] Numeric?(#T) = Integer?(T) or Float?(T) or Imaginary?(T);
 [A, B] overload Numeric?(#A, #B) = Numeric?(A) and Numeric?(B);

--- a/test/numbers/test.clay
+++ b/test/numbers/test.clay
@@ -1,0 +1,45 @@
+import printer.*;
+import test.*;
+
+main() = testMain(
+    TestSuite("numbers", array(
+        TestCase("*IntegerOfSize", test => {
+            ..for (type in ..BuiltinIntegerTypes()) {
+                if (SignedInteger?(type)) {
+                    expectEqual(test, type, type, SignedIntegerOfSize(#Int(TypeSize(type))));
+                } else {
+                    expectEqual(test, type, type, UnsignedIntegerOfSize(#Int(TypeSize(type))));
+                }
+            }
+        }),
+        TestCase("SignedInteger, UnsignedInteger", test => {
+            ..for (type in ..BuiltinIntegerTypes()) {
+                if (SignedInteger?(type)) {
+                    expectEqual(test, type,
+                        type,
+                        SignedInteger(type));
+                    expectNotEqual(test, str("UnsignedInteger of ", type),
+                        type,
+                        UnsignedInteger(type));
+                    expectEqual(test, str("SignedInteger of UnsignedInteger of ", type),
+                        type,
+                        SignedInteger(UnsignedInteger(type)));
+                } else {
+                    expectEqual(test, type,
+                        type,
+                        UnsignedInteger(type));
+                    expectNotEqual(test, str("SignedInteger of ", type),
+                        type,
+                        SignedInteger(type));
+                    expectEqual(test, str("UnsignedInteger of SignedInteger of ", type),
+                        type,
+                        UnsignedInteger(SignedInteger(type)));
+                }
+
+                expectEqual(test, str("size of UnsignedInteger of ", type),
+                    TypeSize(type), TypeSize(UnsignedInteger(type)));
+                expectEqual(test, str("size of SignedInteger of ", type),
+                    TypeSize(type), TypeSize(SignedInteger(type)));
+            }
+        }),
+    )));


### PR DESCRIPTION
- BuiltinIntegerTypes
- SignedIntegerOfSize, UnsignedIntegerOfSize
- SignedInteger, UnsignedInteger
- BuiltinFloatTypes, BuiltinImaginaryTypes

There is no FloatOfSize or ImaginaryOfSize, because there is no
single float type for given size, for instance, 16 byte float types
are Float80 and (not yet existing) Float128.

UnsignedIntegerOfSize can be used, for example, in generic cryptography
algorithms. Most algorithms have state that is N words of size K
each. So state data can be represented in generic code with expression

```
Array[UnsignedIntegerOfSize(K), N]
```

BuiltinIntegerTypes are useful in tests to check that generic code
works properly with all data types.
