### PR TITLE
revert addition of arrayValues function

### DIFF
--- a/lib-clay/byteorder/common/common.clay
+++ b/lib-clay/byteorder/common/common.clay
@@ -16,7 +16,7 @@ overload networkToHost(n:I) --> returned:I {
     alias A = Array[UInt8, Int(TypeSize(I))];
     ref bytes = bitcast(A, n);
     ref returnedBytes = bitcast(A, returned);
-    returnedBytes <-- array(..reverseValues(..arrayValues(bytes)));
+    returnedBytes <-- array(..reverseValues(..arrayElements(bytes)));
 }
 
 [I8 when inValues?(I8, Int8, UInt8)]

--- a/lib-clay/core/arrays/arrays.clay
+++ b/lib-clay/core/arrays/arrays.clay
@@ -218,12 +218,6 @@ integerArray(#n) = array(..integers(#n));
 
 
 
-/// @section arrayValues
-[T, n]
-arrayValues(a: Array[T,n]) = ..mapValues(i -> a[i], ..integers(#n));
-
-
-
 /// @section  array assignment 
 
 [T,U,n when not (T == U and BitwiseAssignedType?(T)) and CallDefined?(assign, T, U)]

--- a/test/arrays/test.clay
+++ b/test/arrays/test.clay
@@ -2,15 +2,15 @@ import test.*;
 
 main() = testMain(
     TestSuite("arrays", array(
-        TestCase("arrayValues", test => {
+        TestCase("arrayElements", test => {
             expectEqual(test, "array 0",
                 [],
-                [..arrayValues(Array[Int, 0]())]);
+                [..arrayElements(Array[Int, 0]())]);
             expectEqual(test, "array 1",
                 [true],
-                [..arrayValues(array(true))]);
+                [..arrayElements(array(true))]);
             expectEqual(test, "array 2",
                 [4, 5],
-                [..arrayValues(array(4, 5))]);
+                [..arrayElements(array(4, 5))]);
         }),
     )));

--- a/test/byteorder/test.clay
+++ b/test/byteorder/test.clay
@@ -7,7 +7,7 @@ import test.*;
 testNetworkToHost(test, #IntType, function) {
     alias S = #TypeSize(IntType);
     var digits = array(..mapValues(i -> UInt8(250 - i), ..integers(S)));
-    var digitsReversed = array(..reverseValues(..arrayValues(digits)));
+    var digitsReversed = array(..reverseValues(..arrayElements(digits)));
     var expected = if (LittleEndian?) digitsReversed else digits;
     expectEqual(test, str(function, " ", IntType),
         expected,


### PR DESCRIPTION
Clay has arrayElements builtin. Test is kept.
