### PR TITLE
fix replicateValue for unsigned parameter

### DIFF
--- a/lib-clay/core/values/values.clay
+++ b/lib-clay/core/values/values.clay
@@ -77,9 +77,10 @@ overload lastValue(forward a) = forward a;
 
 /// @section  replicateValue, allValues?, anyValues?, equalValues?, inValues? 
 
-[n]
+[n when n > 0]
 forceinline replicateValue(a, #n) = a, ..replicateValue(a, #(n-1));
-forceinline overload replicateValue(a, #0) = ;
+[n when n == 0]
+forceinline overload replicateValue(a, #n) = ;
 
 forceinline allValues?(pred, ..rest) {
     ..for (x in rest) {

--- a/test/values/1/test.clay
+++ b/test/values/1/test.clay
@@ -164,4 +164,17 @@ main() = testMain(
                 assocValue("bar", ["foo", 1, 2, 3], ["bar", 4])
             );
         }),
+        TestCase("replicateValue", test => {
+            ..for (Type in Int, UInt, Int8, UInt8, SizeT) {
+                expectEqual(test, "replicateValue(x, #" ++ StaticName(Type) ++ "(0))",
+                    [],
+                    [..replicateValue(true, #Type(0))]);
+                expectEqual(test, "replicateValue(x, #" ++ StaticName(Type) ++ "(1)",
+                    [17],
+                    [..replicateValue(17, #Type(1))]);
+                expectEqual(test, "replicateValue(x, #" ++ StaticName(Type) ++ "(3)",
+                    ['a', 'a', 'a'],
+                    [..replicateValue('a', #Type(3))]);
+            }
+        }),
     )));


### PR DESCRIPTION
```
replicateValue(true, #3u);
```
