### PR TITLE
parsec: use StringLiteralRef in implementation of literalString function

### DIFF
--- a/lib-clay/parsing/combinators/generic/generic.clay
+++ b/lib-clay/parsing/combinators/generic/generic.clay
@@ -186,9 +186,9 @@ literalString(#TokenInput, forward a:A) {
 }
 
 [TokenInput, S when
-    Static?(S) and Sequence?(Type(S)) and (SequenceElementType(Type(S)) == TokenType(TokenInput))]
+    StringLiteral?(S) and Sequence?(Type(S)) and (SequenceElementType(Type(S)) == TokenType(TokenInput))]
 overload literalString(#TokenInput, #S) =
-    literalString(#TokenInput, coordinateRange(begin(S), end(S)));
+    literalString(#TokenInput, StringLiteralRef(S));
     
 
 


### PR DESCRIPTION
as suggested in https://github.com/jckarter/clay/pull/326#discussion_r1362567
