### PR TITLE
io.temp: fix compilation on win64

### DIFF
--- a/lib-clay/io/temp/platform/platform.windows.clay
+++ b/lib-clay/io/temp/platform/platform.windows.clay
@@ -1,4 +1,4 @@
-import win32.(GetTempPathA, LPTSTR, GetLastError);
+import win32.(GetTempPathA, LPTSTR, DWORD, GetLastError);
 import strings.(String);
 import io.errors.(GenericIOError);
 
@@ -7,7 +7,7 @@ private alias MAX_PATH = 260;
 
 tempDirectory() {
     var buffer = Array[Char, MAX_PATH + 1]();
-    var r = GetTempPathA(size(buffer), LPTSTR(@buffer));
+    var r = GetTempPathA(DWORD(size(buffer)), LPTSTR(@buffer));
     if (r == 0) {
         throw GenericIOError(GetLastError(), "GetTempPathA");
     }
@@ -17,7 +17,7 @@ tempDirectory() {
 
     var bigBuffer = String();
     resize(bigBuffer, r + 1);
-    var r2 = GetTempPathA(size(bigBuffer), LPTSTR(begin(bigBuffer)));
+    var r2 = GetTempPathA(DWORD(size(bigBuffer)), LPTSTR(begin(bigBuffer)));
     if (r2 == 0) {
         throw GenericIOError(GetLastError(), "GetTempPathA");
     }


### PR DESCRIPTION
Fixing this error:
https://github.com/erg/claybuild-win64/blob/55f37e2/testlog.txt
