### PR TITLE
CapturedValue? protocol

### DIFF
--- a/lib-clay/core/values/values.clay
+++ b/lib-clay/core/values/values.clay
@@ -111,27 +111,39 @@ private record CapturedLValue[T] (
     ptr : Pointer[T]
 );
 
-define captureValue;
-forceinline overload captureValue(rvalue x) = move(x);
+private record CapturedRValue[T] (
+    value: T
+);
+
+CapturedValue?(a) = false;
+[T]
+overload CapturedValue?(#CapturedLValue[T]) = true;
+[T]
+overload CapturedValue?(#CapturedRValue[T]) = true;
+
+define captureValue(v);
+forceinline overload captureValue(rvalue x) = CapturedRValue(move(x));
 forceinline overload captureValue(ref x) = CapturedLValue(@x);
 
-define forwardValue;
-forceinline overload forwardValue(x) = move(x);
+[V when CapturedValue?(V)]
+define forwardValue(v:V);
+[T] forceinline overload forwardValue(x:CapturedRValue[T]) = move(x.value);
 [T] forceinline overload forwardValue(x:CapturedLValue[T]) = ref x.ptr^;
 
-define capturedRef;
-forceinline overload capturedRef(x) = ref x;
+[V when CapturedValue?(V)]
+define capturedRef(v:V);
+[T] forceinline overload capturedRef(x:CapturedRValue[T]) = ref x.value;
 [T] forceinline overload capturedRef(x:CapturedLValue[T]) = ref x.ptr^;
 
 // captureValues, forwardValues, capturedRefs
 
 forceinline captureValues(forward ..args) = Tuple(..mapValues(captureValue, ..args));
 
-[..T]
+[..T when allValues?(CapturedValue?, ..T)]
 forceinline forwardValues(x:Tuple[..T]) =
     forward ..mapValues(forwardValue, ..unpackTupleRef(x));
 
-[..T]
+[..T when allValues?(CapturedValue?, ..T)]
 forceinline capturedRefs(x:Tuple[..T]) =
     forward ..mapValues(capturedRef, ..unpackTupleRef(x));
 

--- a/lib-clay/printer/formatter/formatter.clay
+++ b/lib-clay/printer/formatter/formatter.clay
@@ -147,22 +147,24 @@ overload printedWidth(b: Bool) = if (b) 4 else 5;
 
 /// @section  minimum-width alignment formatter 
 
-private record LeftAlignedFormatter[T] (
-    value: T,
+[..C when allValues?(CapturedValue?, ..C)]
+private record LeftAlignedFormatter[..C] (
+    value: Tuple[..C],
     width: SizeT,
     filledWidth: SizeT,
     pad: Char,
 );
-private record RightAlignedFormatter[T] (
-    value: T,
+[..C when allValues?(CapturedValue?, ..C)]
+private record RightAlignedFormatter[..C] (
+    value: Tuple[..C],
     width: SizeT,
     filledWidth: SizeT,
     pad: Char,
 );
 
 private AlignedFormatter?(T) = false;
-[T] overload AlignedFormatter?(#LeftAlignedFormatter[T]) = true;
-[T] overload AlignedFormatter?(#RightAlignedFormatter[T]) = true;
+[..C] overload AlignedFormatter?(#LeftAlignedFormatter[..C]) = true;
+[..C] overload AlignedFormatter?(#RightAlignedFormatter[..C]) = true;
 [T when AlignedFormatter?(T)] overload Formatter?(#T) = true;
 
 [I when Integer?(I)]
@@ -193,8 +195,8 @@ leftAligned(width, forward ..values)
 rightAligned(width, forward ..values)
     = alignedFormatter(RightAlignedFormatter, width, ' ', ..values);
 
-[T]
-overload printTo(stream, f: LeftAlignedFormatter[T]) {
+[..C]
+overload printTo(stream, f: LeftAlignedFormatter[..C]) {
     printTo(stream, ..forwardValues(f.value));
     var i = f.filledWidth;
     while (i < f.width) {
@@ -202,8 +204,8 @@ overload printTo(stream, f: LeftAlignedFormatter[T]) {
         i +: 1;
     }
 }
-[T]
-overload printTo(stream, f: RightAlignedFormatter[T]) {
+[..C]
+overload printTo(stream, f: RightAlignedFormatter[..C]) {
     var i = f.filledWidth;
     while (i < f.width) {
         printTo(stream, f.pad);

--- a/lib-clay/printer/formatter/formatter.clay
+++ b/lib-clay/printer/formatter/formatter.clay
@@ -171,7 +171,7 @@ private alignedFormatter(F, width: I, pad: Char, forward ..values) {
     // and use the width of that
     var s = str(..values);
     var filledWidth = size(s);
-    return formatter(F, Tuple(move(s)), SizeT(width), filledWidth, pad);
+    return F(captureValues(move(s)), SizeT(width), filledWidth, pad);
 }
 
 private filledWidth(..values)

--- a/test/values/1/test.clay
+++ b/test/values/1/test.clay
@@ -5,6 +5,33 @@ import test.*;
 
 even?(x) = x % 2 == 0;
 
+
+// non-copyable, non-constructible record
+record NonConstructibleRecord ();
+
+overload RegularRecord?(#NonConstructibleRecord) = false;
+
+makeNonConstructibleRecord(foo: Int) --> returned: NonConstructibleRecord { }
+
+overload moveUnsafe(src: NonConstructibleRecord) --> returned: NonConstructibleRecord { }
+overload resetUnsafe(foo: NonConstructibleRecord) { }
+overload destroy(foo: NonConstructibleRecord) { }
+
+expectRef(ref a) {}
+expectRValue(rvalue a) {}
+
+testCaptureValue(test) {
+    var capture1 = captureValue(makeNonConstructibleRecord(17));
+    expectRef(capturedRef(capture1));
+    expectRValue(forwardValue(capture1));
+
+    var lva = makeNonConstructibleRecord(19);
+    var capture2 = captureValue(lva);
+    expectRef(capturedRef(capture2));
+    expectRef(forwardValue(capture2));
+}
+
+
 main() = testMain(
     TestSuite("values", array(
         TestCase("eachValue", test => {
@@ -177,4 +204,5 @@ main() = testMain(
                     [..replicateValue('a', #Type(3))]);
             }
         }),
+        TestCase("captureValue", testCaptureValue),
     )));


### PR DESCRIPTION
`captureValue` now returns a value that conforms to `CapturedValue?` predicate.  `forwardValue` and `capturedRef` functions now require parameter to be of type `CapturedValue?`.

Included a patch that fixes printer.formatter that misused captureValue, forwardValue functions.
