### PR TITLE
alias ArrayRef[T] = CoordinateRange[Pointer[T]]

### DIFF
--- a/lib-clay/core/arrays/arrays.clay
+++ b/lib-clay/core/arrays/arrays.clay
@@ -229,3 +229,19 @@ overload assign(ref left: Array[T,n], ref right: Array[U, n]) {
 overload assign(ref left: Array[T,n], rvalue right: Array[U, n]) {
     moveAssignNonoverlappingMemory(begin(left), begin(right), end(right));
 }
+
+
+
+
+
+/// @section  ArrayRef
+/// ArrayRef is a pair of pointers to the begin and to the end of memory area
+
+alias ArrayRef[T] = CoordinateRange[Pointer[T]];
+
+[T]
+overload ArrayRef(begin: Pointer[T], end: Pointer[T]) = CoordinateRange(begin, end);
+
+[T,N]
+overload ArrayRef(a: Array[T,N]) = ArrayRef(begin(a), end(a));
+

--- a/lib-clay/core/strings/stringrefs/stringrefs.clay
+++ b/lib-clay/core/strings/stringrefs/stringrefs.clay
@@ -1,7 +1,7 @@
-import core.ranges.*;
+import core.arrays.*;
 import core.strings.*;
 
-alias StringRef = CoordinateRange[Pointer[Char]];
+alias StringRef = ArrayRef[Char];
 
 [S when ContiguousString?(S)]
-overload StringRef(s: S) = StringRef(begin(s), end(s));
+overload StringRef(s: S) = ArrayRef(begin(s), end(s));

--- a/lib-clay/core/system/system.clay
+++ b/lib-clay/core/system/system.clay
@@ -3,7 +3,7 @@ import core.libc as libc;
 
 private var argc = 0;
 private var argv = Pointer[Pointer[Int8]]();
-private var commandLineArgs = CoordinateRange[Pointer[CStringRef]]();
+private var commandLineArgs = ArrayRef[CStringRef]();
 
 commandLine() = ref commandLineArgs;
 

--- a/lib-clay/printer/types/types.clay
+++ b/lib-clay/printer/types/types.clay
@@ -380,6 +380,11 @@ overload printReprTo(stream, #S) {
     printTo(stream, StaticName(S));
 }
 
+[T]
+overload printReprTo(stream, #ArrayRef[T]) {
+    printTo(stream, ArrayRef, "[", T, "]");
+}
+
 overload printReprTo(stream, #String) {
     printTo(stream, "String");
 }

--- a/test/arrays/arrayref/test.clay
+++ b/test/arrays/arrayref/test.clay
@@ -1,0 +1,10 @@
+import test.*;
+
+
+main() = testMain(
+    TestSuite("core.arrays.ArrayRef", array(
+        TestCase("constructor", test => {
+            var a = array(3, 5, 8);
+            expectEqual(test, "ArrayRef", ArrayRef(a), a);
+        }),
+    )));

--- a/test/printing/repr/test.clay
+++ b/test/printing/repr/test.clay
@@ -1,8 +1,9 @@
 import printer.formatter.(repr);
 import numbers.floats.(nan, nan?);
-import printer.(println);
+import printer.(println, str);
 import strings.(String);
 import complex.*;
+import algorithms.*;
 
 import test.*;
 
@@ -117,6 +118,10 @@ main() = testMain(
             testWithEval(test, """CStringRef()""");
             testWithEval(test, """StringRef("string ref")""");
             testWithEval(test, """StringRef()""");
+        }),
+        TestCase("ArrayRef", test => {
+            testWithEval(test, """ArrayRef[Int32]""");
+            // content printing is not tested, because output contains pointers
         }),
     )));
 


### PR DESCRIPTION
- alias and utilities
- redefine StringRef as ArrayRef[Char]
