### PR TITLE
runtests.py: print path to clay executable

### DIFF
--- a/test/runtests.py
+++ b/test/runtests.py
@@ -384,6 +384,9 @@ def runTests(opt):
         print "cpu:", arch
         print "bits:", bits
         print
+        print "[Compiler]"
+        print "exe:", opt.clayCompiler
+        print
         print "[Tests]"
         for test in testcases:
             res, log = results.next()


### PR DESCRIPTION
To be sure that I'm testing with proper compiler.
