### PR TITLE
split `push` to `push` and `pushAll` (and related changes)

### DIFF
--- a/lib-clay/algorithms/algorithms.clay
+++ b/lib-clay/algorithms/algorithms.clay
@@ -287,23 +287,27 @@ overload advancePast(pos:C, x:T) {
 
 /// @section  join 
 
+define join(sep, seq);
+
 [S, A when Sequence?(A) and Sequence?(SequenceElementType(A))
-        and ((S == SequenceElementType(SequenceElementType(A)))
-             or (Sequence?(S)
-                 and (SequenceElementType(S) == SequenceElementType(SequenceElementType(A)))))]
-join(sep:S, a:A) {
+    and Sequence?(S) and (SequenceElementType(S) == SequenceElementType(SequenceElementType(A)))]
+overload join(sep:S, a:A) {
     alias T = SequenceElementType(SequenceElementType(A));
     var result = Vector[T]();
     var first = true;
     for (x in a) {
         if (not first)
-            push(result, sep);
+            pushAll(result, sep);
         else
             first = false;
-        push(result, x);
+        pushAll(result, x);
     }
     return move(result);
 }
+
+[S, A when Sequence?(A) and Sequence?(SequenceElementType(A))
+        and S == SequenceElementType(SequenceElementType(A))]
+overload join(sep:S, a:A) = ..join(array(sep), a);
 
 
 

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -117,6 +117,9 @@ define back(s:S);
 [S] // when Sequence?(S)
 define push(s:S, ..vs) :;
 
+[S, Vs when Sequence?(S) and Sequence?(Vs)]
+define pushAll(s:S, vs:Vs) :;
+
 [S when Sequence?(S)]
 define pop(s:S);
 
@@ -125,6 +128,9 @@ define clear(s) :;
 
 [S when Sequence?(S)]
 define insert(s:S, coord, v) :;
+
+[S, Vs when Sequence?(S) and Sequence?(Vs)]
+define insertAll(s:S, coord, vs:Vs) :;
 
 // defined for collections
 define remove;
@@ -144,6 +150,24 @@ define pushFront(s:S, v) :;
 
 [S when Sequence?(S)]
 define popFront(s:S);
+
+
+
+// default implementation using `push`
+overload pushAll(s, vs) {
+    for (v in vs) {
+        push(s, v);
+    }
+}
+
+// default implementation using `insert`
+overload insertAll(s, coord, vs) {
+    var insertPoint = coord;
+    for (v in vs) {
+        insert(v, insertPoint, vs);
+        insertPoint +: 1;
+    }
+}
 
 
 // defined for statically sized sequences like Array[T,n]

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -151,6 +151,15 @@ define popFront(s:S);
 define StaticSize(#S);
 
 
+overload push(s) {}
+
+overload push(s, forward v1, forward v2, forward ..vs) {
+    ..for (v in v1, v2, ..vs) {
+        push(s, v);
+    }
+}
+
+
 
 /// @section  sequence type predicates 
 

--- a/lib-clay/deques/deques.clay
+++ b/lib-clay/deques/deques.clay
@@ -234,14 +234,16 @@ overload Deque(forward from:A) = Deque(mapped(Tuple, from));
         pushFrontDeque1(deque, value);
 }
 
+define pushFrontAll(s, vs);
+
 [T, S when Sequence?(S) and SequenceElementType(S) == T]
-overload pushFront(deque: Deque[T], forward seq: S) {
+overload pushFrontAll(deque: Deque[T], forward seq: S) {
     for (x in reversed(seq))
         pushFront(deque, x);
 }
 
 [T, S when SizedSequence?(S) and SequenceElementType(S) == T]
-overload pushFront(deque: Deque[T], forward seq: S) {
+overload pushFrontAll(deque: Deque[T], forward seq: S) {
     var seqSize = size(seq);
     deque.begin = reserveDequeFrontElements(deque, seqSize);
     var i = deque.begin + seqSize;
@@ -257,7 +259,7 @@ overload pushFront(deque: Deque[T], forward seq: S) {
     }
 }
 
-[T] overload push(deque: Deque[T], forward value) {
+[T] overload push(deque: Deque[T], forward value: T) {
     if (deque.end.current != deque.end.last - 1) {
         deque.end.current^ <-- value;
         deque.end.current +: 1;
@@ -265,14 +267,8 @@ overload pushFront(deque: Deque[T], forward seq: S) {
         pushDeque1(deque, value);
 }
 
-[T, S when Sequence?(S) and SequenceElementType(S) == T]
-overload push(deque: Deque[T], forward seq: S) {
-    for (x in seq)
-        push(deque, x);
-}
-
 [T, S when SizedSequence?(S) and SequenceElementType(S) == T]
-overload push(deque: Deque[T], forward seq: S) {
+overload pushAll(deque: Deque[T], forward seq: S) {
     var seqSize = size(seq);
     deque.end = reserveDequeBackElements(deque, seqSize);
     var i = deque.end - seqSize;
@@ -311,11 +307,11 @@ overload push(deque: Deque[T], forward seq: S) {
 }
 
 [T, I when Integer?(I)]
-overload insert(deque: Deque[T], n: I, forward value) {
+overload insert(deque: Deque[T], n: I, forward value: T) {
     insert(deque, deque.begin + n, value);
 }
 
-[T] overload insert(deque: Deque[T], i: DequeCoordinate[T], forward value) {
+[T] overload insert(deque: Deque[T], i: DequeCoordinate[T], forward value: T) {
     assert["boundsChecks"](validDequeCoordinate?(deque, i),
         "invalid insert coordinate into ", Deque[T]);
     if (i.current == deque.begin.current)
@@ -332,13 +328,13 @@ overload insert(deque: Deque[T], n: I, forward seq: S) {
 }
 
 [T, S when Sequence?(S) and SequenceElementType(S) == T]
-overload insert(deque: Deque[T], i: DequeCoordinate[T], forward seq: S) {
+overload insertAll(deque: Deque[T], i: DequeCoordinate[T], forward seq: S) {
     assert["boundsChecks"](validDequeCoordinate?(deque, i),
         "invalid insert coordinate into ", Deque[T]);
     if (i.current == deque.begin.current)
-        pushFront(deque, seq);
+        pushFrontAll(deque, seq);
     else if (i.current == deque.end.current)
-        push(deque, seq);
+        pushAll(deque, seq);
     else
         insertDequeSequence(deque, i, seq);
 }

--- a/lib-clay/io/paths/paths.unix.clay
+++ b/lib-clay/io/paths/paths.unix.clay
@@ -84,7 +84,7 @@ private appendPath(path:String, part) {
     else {
         if ((not empty?(path)) and (not endsWith?(path, '/')))
             push(path, '/');
-        push(path, part);
+        pushAll(path, part);
     }
 }
 

--- a/lib-clay/paged/vectors/vectors.clay
+++ b/lib-clay/paged/vectors/vectors.clay
@@ -57,12 +57,9 @@ overload Vector(a:A) {
 alias overload Vector[T](..args:A) {
     var v = Vector[T]();
     reserve(v, countValues(..A));
-    pushAll(v, ..args);
+    push(v, ..args);
     return move(v);
 }
-
-private pushAll(a, forward x, forward ..rest) { push(a, x); pushAll(a, ..rest); }
-overload pushAll(a) {}
 
 
 

--- a/lib-clay/sequences/operators/operators.clay
+++ b/lib-clay/sequences/operators/operators.clay
@@ -70,7 +70,7 @@ forceinline overload reduceToScalar(forward i) = ;
             ..mapValues(SequenceElementType,..B)) and not StringLiteralType?(A,..B)]
 overload (++)(forward a:A, forward ..b:B) {
     var result = Vector(a);
-    push(result, ..b);
+    pushAll(result, ..b);
     return move(result);
 }
 
@@ -90,8 +90,10 @@ overload removeCatFromList(forward a, #cat, forward ..args) = forward a, ..remov
 overload removeCatFromList(forward a) = forward a;
 
 [A, ..B when Sequence?(A)]
-overload updateAssign(#(++), forward a:A, forward ..b:B) {
-    push(a, ..removeCatFromList(..b));
+overload updateAssign(#(++), forward a:A, forward ..bs:B) {
+    ..for (b in ..removeCatFromList(..bs)) {
+        pushAll(a, b);
+    }
 }
 
 [A, T when Sequence?(A) and (SequenceElementType(A) == T)]

--- a/lib-clay/sequences/operators/operators.clay
+++ b/lib-clay/sequences/operators/operators.clay
@@ -94,11 +94,6 @@ overload updateAssign(#(++), forward a:A, forward ..b:B) {
     push(a, ..removeCatFromList(..b));
 }
 
-[A, ..T when Sequence?(A)]
-overload updateAssign(#(++), forward a:A, forward ..x:T) {
-    push(a, ..removeCatFromList(..x));
-}
-
 [A, T when Sequence?(A) and (SequenceElementType(A) == T)]
 overload updateAssign(#(++), forward x:T, forward a:A) {
     insert(a,0,x);

--- a/lib-clay/test/test.clay
+++ b/lib-clay/test/test.clay
@@ -215,7 +215,7 @@ forceinline expectCallUndefined(test: TestStatus, Proc, ..Types) {
 inline expectIterator(test: TestStatus, name, iter:I, ..expected) {
     var expectedV = Vector[IteratorTargetType(I)](..expected);
     var resultV = Vector[IteratorTargetType(I)]();
-    push(resultV, iter);
+    pushAll(resultV, iter);
     var msg = str(name, " is expected to contain:\n");
     for (expectedX in expectedV)
         push(msg, TEST_FAIL_CASE_INDENT, str(repr(expectedX)),"\n");

--- a/lib-clay/vectors/generic/generic.clay
+++ b/lib-clay/vectors/generic/generic.clay
@@ -68,8 +68,8 @@ forceinline overload front(a:V) = ref a[0];
 forceinline overload back(a:V) = ref a[size(a) - 1];
 
 [V, S when Vector?(V) and Sequence?(S) and (SequenceElementType(S) == SequenceElementType(V))]
-overload push(a:V, forward seq:S) {
-    insert(a, size(a), seq);
+overload pushAll(a:V, forward seq:S) {
+    insertAll(a, size(a), seq);
 }
 
 [V, T when Vector?(V) and (SequenceElementType(V) == T)]
@@ -147,7 +147,7 @@ overload insertLocationsUnsafe(a, pos:SizeT, n:SizeT) {
 
 [V,I,S when Vector?(V) and Integer?(I) and Sequence?(S) and
          (SequenceElementType(S) == SequenceElementType(V))]
-overload insert(a:V, i:I, seq:S) {
+overload insertAll(a:V, i:I, seq:S) {
     assert(i >= 0 and i <= size(a), "invalid position for insert into ", V);
     var pos = SizeT(i);
     for (x in seq) {
@@ -158,7 +158,7 @@ overload insert(a:V, i:I, seq:S) {
 
 [V,I,S when Vector?(V) and Integer?(I) and SizedSequence?(S) and
          (SequenceElementType(S) == SequenceElementType(V))]
-overload insert(a:V, i:I, seq:S) {
+overload insertAll(a:V, i:I, seq:S) {
     assert(i >= 0 and i <= size(a), "invalid position for insert into ", V);
     var first, last = ..insertLocationsUnsafe(a, i, size(seq));
     try {
@@ -176,7 +176,7 @@ overload insert(a:V, i:I, seq:S) {
 [V,I,S when Vector?(V) and Integer?(I)
          and SizedSequence?(S) and ContiguousSequence?(S)
          and (SequenceElementType(S) == SequenceElementType(V))]
-overload insert(a:V, i:I, seq:S) {
+overload insertAll(a:V, i:I, seq:S) {
     assert(i >= 0 and i <= size(a), "invalid position for insert into ", V);
     var first, last = ..insertLocationsUnsafe(a, i, size(seq));
     try {
@@ -192,7 +192,7 @@ overload insert(a:V, i:I, seq:S) {
 [V,I,S when Vector?(V) and Integer?(I)
          and SequenceContainer?(S) and SizedSequence?(S)
          and (SequenceElementType(S) == SequenceElementType(V))]
-overload insert(a:V, i:I, rvalue seq:S) {
+overload insertAll(a:V, i:I, rvalue seq:S) {
     assert(i >= 0 and i <= size(a), "invalid position for insert into ", V);
     var first, last = ..insertLocationsUnsafe(a, i, size(seq));
     for (x in seq) {
@@ -204,7 +204,7 @@ overload insert(a:V, i:I, rvalue seq:S) {
 [V,I,S when Vector?(V) and Integer?(I)
          and SequenceContainer?(S) and ContiguousSequence?(S)
          and (SequenceElementType(S) == SequenceElementType(V))]
-overload insert(a:V, i:I, rvalue seq:S) {
+overload insertAll(a:V, i:I, rvalue seq:S) {
     assert(i >= 0 and i <= size(a), "invalid position for insert into ", V);
     var first, last = ..insertLocationsUnsafe(a, i, size(seq));
     var src = begin(seq);
@@ -226,7 +226,7 @@ overload insert(a:V, i:I, rvalue x:T) {
 
 [V,T,S when Vector?(V) and (SequenceElementType(V) == T) and
          Sequence?(S) and (SequenceElementType(S) == T)]
-overload insert(a:V, i:VectorCoordinate[T], forward seq:S) {
+overload insertAll(a:V, i:VectorCoordinate[T], forward seq:S) {
     insert(a, i-begin(a), seq);
 }
 

--- a/lib-clay/vectors/generic/generic.clay
+++ b/lib-clay/vectors/generic/generic.clay
@@ -86,9 +86,6 @@ forceinline overload push(v:V, forward e1:A1, forward e2:A2, forward ..ee:AA) {
 }
 
 [V when Vector?(V)]
-forceinline overload push(v:V) { }
-
-[V when Vector?(V)]
 overload pop(a:V) {
     assert(not empty?(a), "pop of empty ", V);
     var temp = moveUnsafe(back(a));

--- a/lib-clay/vectors/vectors.clay
+++ b/lib-clay/vectors/vectors.clay
@@ -41,7 +41,7 @@ overload Vector[T]() = Vector[T](SizeT(0), SizeT(0), null(T));
 [T,A when Sequence?(A) and (T == SequenceElementType(A))]
 overload Vector[T](forward a:A) {
     var v = Vector[T]();
-    push(v, a);
+    pushAll(v, a);
     return move(v);
 }
 

--- a/test/computedrecords/2/main.clay
+++ b/test/computedrecords/2/main.clay
@@ -31,7 +31,7 @@ alias VPoint = Vectorized[Point];
 
 main() {
     var a = VPoint();
-    push(a.x, array(1, 2, 3));
-    push(a.y, array(4, 5, 6));
+    pushAll(a.x, array(1, 2, 3));
+    pushAll(a.y, array(4, 5, 6));
     println(a);
 }

--- a/test/deques/main.clay
+++ b/test/deques/main.clay
@@ -263,25 +263,25 @@ main() {
     for (x in d7) print(x, " ");
     println();
 
-    insert(d7, begin(d7), range(5));
+    insertAll(d7, begin(d7), range(5));
     println("Insert sequence front size ", size(d7));
     print("Contents: ");
     for (x in d7) print(x, " ");
     println();
 
-    insert(d7, end(d7), range(36, 41));
+    insertAll(d7, end(d7), range(36, 41));
     println("Insert sequence back size ", size(d7));
     print("Contents: ");
     for (x in d7) print(x, " ");
     println();
 
-    insert(d7, begin(d7) + 6, range(6, 10));
+    insertAll(d7, begin(d7) + 6, range(6, 10));
     println("Insert sequence front half size ", size(d7));
     print("Contents: ");
     for (x in d7) print(x, " ");
     println();
 
-    insert(d7, end(d7) - 6, range(31, 35));
+    insertAll(d7, end(d7) - 6, range(31, 35));
     println("Insert sequence back half size ", size(d7));
     print("Contents: ");
     for (x in d7) print(x, " ");

--- a/test/deques/memory/main.clay
+++ b/test/deques/memory/main.clay
@@ -157,16 +157,16 @@ test() {
     var d10 = Deque[Canary](Canary(), Canary(), Canary());
 
     println("inserting d10 into d9 front");
-    insert(d9, begin(d9), d10);
+    insertAll(d9, begin(d9), d10);
 
     println("inserting d10 into d9 back");
-    insert(d9, end(d9), d10);
+    insertAll(d9, end(d9), d10);
 
     println("inserting d10 into d9 front half sequence");
-    insert(d9, begin(d9) + 2, d10);
+    insertAll(d9, begin(d9) + 2, d10);
 
     println("inserting d10 into d9 back half sequence");
-    insert(d9, end(d9) - 2, d10);
+    insertAll(d9, end(d9) - 2, d10);
 
     println("making deque d11");
     var d11 = Deque[Canary](Canary(), Canary(), Canary(), Canary());
@@ -193,7 +193,7 @@ test() {
         var d14 = d11;
 
         println("inserting into d14 front half sequence with throw");
-        insert(d14, begin(d14) + 1, throwerDeque);
+        insertAll(d14, begin(d14) + 1, throwerDeque);
     } catch(x) {}
 
     try {
@@ -201,7 +201,7 @@ test() {
         var d15 = d11;
 
         println("inserting into d15 back half sequence with throw");
-        insert(d15, end(d15) - 1, throwerDeque);
+        insertAll(d15, end(d15) - 1, throwerDeque);
     } catch(x) {}
 
     try {
@@ -209,7 +209,7 @@ test() {
         var d16 = d11;
 
         println("pushing sequence onto deque d16 with throw");
-        push(d16, throwerDeque);
+        pushAll(d16, throwerDeque);
     } catch(x) {}
 
     try {
@@ -217,7 +217,7 @@ test() {
         var d17 = d11;
 
         println("pushing sequence onto front of deque d17 with throw");
-        pushFront(d17, throwerDeque);
+        pushFrontAll(d17, throwerDeque);
     } catch(x) {}
 
     println("d1, d7, d8, d9, d10, d11 leaving scope");

--- a/test/exceptions/finally/main.clay
+++ b/test/exceptions/finally/main.clay
@@ -15,7 +15,7 @@ bar(str, throw?) {
     println("--> bar");
 
     var s = String("abc");
-    push(s, str);
+    pushAll(s, str);
     finally println("<-- ", s);
 
     println("lalala");

--- a/test/exceptions/onerror/main.clay
+++ b/test/exceptions/onerror/main.clay
@@ -16,7 +16,7 @@ bar(str, throw?) {
     println("--> bar");
 
     var s = String("abc");
-    push(s, str);
+    pushAll(s, str);
     onerror println("<-- threw, s = ", s);
 
     println("lalala");

--- a/test/sequences/buffervector/main.clay
+++ b/test/sequences/buffervector/main.clay
@@ -13,7 +13,7 @@ main() {
     }
     {
         var bv = BufferVector(begin(buf), begin(buf) + 11);
-        push(bv, "Hello World");
+        pushAll(bv, "Hello World");
         println(size(bv));
         println(bv);
     }

--- a/test/valuesemantics/main.clay
+++ b/test/valuesemantics/main.clay
@@ -48,7 +48,7 @@ overload assign(dest:Test, src:Test) {
 main() {
     var a = Vector[Test](Test(), Test());
     reserve(a, 100);
-    push(a, array(Test(), Test(), Test(), Test(), Test()));
+    pushAll(a, array(Test(), Test(), Test(), Test(), Test()));
     var x = Test();
     push(a, move(x));
 }


### PR DESCRIPTION
Split 'push' and 'pushAll', 'insert' and 'insertAll', 'pushFront'
and 'pushFrontAll'.

Basically,

'xxx' adds single element to sequence
'xxxAll' adds sequence elements

This separation makes:
- simpler overload resolution
- simpler push and other function implementations
- client code easier to read

"All" suffix is chosen after Java collections API (List has add,
addAll methods).  Suggestions of better function names are welcome.
