### PR TITLE
core.types: add more C type aliases

### DIFF
--- a/lib-clay/core/types/platform/platform.64.clay
+++ b/lib-clay/core/types/platform/platform.64.clay
@@ -7,3 +7,5 @@ alias UPtrInt = UInt64;
 
 alias CLong = Int64;
 alias CULong = UInt64;
+
+alias CLongDouble = Float128;

--- a/lib-clay/core/types/platform/platform.windows.32.clay
+++ b/lib-clay/core/types/platform/platform.windows.32.clay
@@ -8,4 +8,5 @@ alias UPtrInt = UInt32;
 alias CLong = Int32;
 alias CULong = UInt32;
 
-alias CLongDouble = Float128;
+// http://msdn.microsoft.com/en-us/library/9cx8xs15.aspx
+alias CLongDouble = Float64;

--- a/lib-clay/core/types/platform/platform.windows.64.clay
+++ b/lib-clay/core/types/platform/platform.windows.64.clay
@@ -7,3 +7,6 @@ alias UPtrInt = UInt64;
 
 alias CLong = Int32;
 alias CULong = UInt32;
+
+// http://msdn.microsoft.com/en-us/library/9cx8xs15.aspx
+alias CLongDouble = Float64;

--- a/lib-clay/core/types/types.clay
+++ b/lib-clay/core/types/types.clay
@@ -4,6 +4,8 @@ public import __operators__.(typeToRValue, typesToRValues);
 
 /// @section  types 
 
+alias CBool = Bool;
+
 alias Byte = UInt8;
 
 alias CChar = Int8;
@@ -11,16 +13,28 @@ alias CUChar = UInt8;
 
 alias Short = Int16;
 alias UShort = UInt16;
+alias CShort = Int16;
+alias CUShort = UInt16;
 
 alias Int = Int32;
 alias UInt = UInt32;
+alias CInt = Int32;
+alias CUInt = UInt32;
 
 alias Long = Int64;
 alias ULong = UInt64;
+// CLong and CULong are different on different platforms
+
+alias CLongLong = Int64;
+alias CULongLong = UInt64;
 
 alias Float = Float32;
 alias Double = Float64;
 alias LongDouble = Float80;
+alias CFloat = Float32;
+alias CDouble = Float64;
+
+// CLongDouble is different on different platforms
 
 alias ComplexFloat = Complex32;
 alias ComplexDouble = Complex64;

--- a/tools/bindgen.clay
+++ b/tools/bindgen.clay
@@ -154,37 +154,37 @@ convertTypeFromDeclaration(declaration:CXCursor) : String {
 convertType(type:CXType, refCursor:CXCursor) : String {
     switch (type.kind)
     case (CXType_Bool)
-        return str("Bool");
+        return str("CBool");
     case (CXType_SChar, CXType_Char_S)
         return str("CChar");
     case (CXType_UChar, CXType_Char_U)
         return str("CUChar");
     case (CXType_UShort)
-        return str("UShort");
+        return str("CUShort");
     case (CXType_UInt)
-        return str("UInt");
+        return str("CUInt");
     case (CXType_ULong)
         return str("CULong");
     case (CXType_ULongLong)
-        return str("UInt64");
+        return str("CULongLong");
     case (CXType_UInt128)
         return str("UInt128");
     case (CXType_Short)
-        return str("Short");
+        return str("CShort");
     case (CXType_Int)
-        return str("Int");
+        return str("CInt");
     case (CXType_Long)
         return str("CLong");
     case (CXType_LongLong)
-        return str("Int64");
+        return str("CLongLong");
     case (CXType_Int128)
         return str("Int128");
     case (CXType_Float)
-        return str("Float");
+        return str("CFloat");
     case (CXType_Double)
-        return str("Double");
+        return str("CDouble");
     case (CXType_LongDouble)
-        return str("LongDouble");
+        return str("CLongDouble");
     case (CXType_Complex) {
         var elementType = clang_getElementType(type);
         switch (elementType.kind)


### PR DESCRIPTION
Add type aliases like CInt, CUint, CShort, CUShort etc.

Although these types are identical on all platforms supported by
Clay, having these type aliases make C-interoperability better in
situations like this:

```
// Developer is not sure that Short is compatible with C short
libc.printf("%hd\n", Short(1));
// This code is obviously correct
libc.printf("%hd\n", CShort(1));
```

bindgen now generates CInt-like types instead of Int-like types.
bindgen did generate long double incorrectly (size of long double
is different between Windows and other platforms).

See http://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
