### PR TITLE
Closed variants

### DIFF
--- a/compiler/src/clay.hpp
+++ b/compiler/src/clay.hpp
@@ -1922,6 +1922,7 @@ struct Variant : public TopLevelItem {
     vector<IdentifierPtr> params;
     IdentifierPtr varParam;
 
+    bool open;
     ExprListPtr defaultInstances;
 
     vector<InstancePtr> instances;
@@ -1934,11 +1935,12 @@ struct Variant : public TopLevelItem {
             ExprPtr predicate,
             const vector<IdentifierPtr> &params,
             IdentifierPtr varParam,
+            bool open,
             ExprListPtr defaultInstances)
         : TopLevelItem(VARIANT, name, visibility),
           patternVars(patternVars), predicate(predicate),
           params(params), varParam(varParam),
-          defaultInstances(defaultInstances) {}
+          open(open), defaultInstances(defaultInstances) {}
 };
 
 struct Instance : public TopLevelItem {

--- a/compiler/src/loader.cpp
+++ b/compiler/src/loader.cpp
@@ -523,6 +523,8 @@ static void initVariantInstance(InstancePtr x) {
         if (z->typeKind != VARIANT_TYPE)
             error(x->target, "not a variant type");
         VariantType *vt = (VariantType *)z;
+        if (!vt->variant->open)
+            error(x->target, "cannot add instances to closed variant");
         vt->variant->instances.push_back(x);
     }
     else {

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -2113,11 +2113,13 @@ static bool instances(ExprListPtr &x) {
     return symbol("(") && optExpressionList(x) && symbol(")");
 }
 
-static bool optInstances(ExprListPtr &x) {
+static bool optInstances(ExprListPtr &x, bool &open) {
     int p = save();
     if (symbol("(")) {
+        open = false;
         return optExpressionList(x) && symbol(")");
     } else {
+        open = true;
         restore(p);
         x = new ExprList();
         return true;
@@ -2138,9 +2140,10 @@ static bool variant(TopLevelItemPtr &x) {
     IdentifierPtr varParam;
     if (!optStaticParams(params, varParam)) return false;
     ExprListPtr defaultInstances;
-    if (!optInstances(defaultInstances)) return false;
+    bool open;
+    if (!optInstances(defaultInstances, open)) return false;
     if (!symbol(";")) return false;
-    x = new Variant(name, vis, patternVars, predicate, params, varParam, defaultInstances);
+    x = new Variant(name, vis, patternVars, predicate, params, varParam, open, defaultInstances);
     x->location = location;
     return true;
 }

--- a/lib-clay/core/exceptions/exceptions.clay
+++ b/lib-clay/core/exceptions/exceptions.clay
@@ -14,9 +14,10 @@ import __operators__.(
 
 /// @section  Exception, NoException, currentException 
 
-variant Exception (NoException);
+variant Exception;
 
 record NoException ();
+instance Exception (NoException);
 
 overload Exception() = Exception(NoException());
 

--- a/lib-clay/io/errors/errors.clay
+++ b/lib-clay/io/errors/errors.clay
@@ -20,9 +20,11 @@ overload printReprTo(stream, x:GenericIOError) {
     printTo(stream, "GenericIOError(", errorCodeName(x.code), ", ", repr(x.where), ")");
 }
 
-variant IOError (GenericIOError);
+variant IOError;
 
 instance OSError (IOError);
+
+instance IOError (GenericIOError);
 
 [T when VariantMember?(IOError, T)]
 overload Exception(forward x:T) = Exception(IOError(x));

--- a/lib-clay/io/sockets/sockets.clay
+++ b/lib-clay/io/sockets/sockets.clay
@@ -28,9 +28,11 @@ public import io.sockets.platform.(
 
 record GenericSocketError (code: Int);
 
-variant SocketError (GenericSocketError);
+variant SocketError;
 
 instance IOError (SocketError);
+
+instance SocketError (GenericSocketError);
 
 [T when VariantMember?(SocketError, T)]
 overload Exception(forward x:T) = Exception(SocketError(x));

--- a/lib-clay/os/errors/errors.clay
+++ b/lib-clay/os/errors/errors.clay
@@ -20,9 +20,11 @@ overload printReprTo(stream, x:GenericOSError) {
     printTo(stream, "GenericOSError(", errorCodeName(x.code), ", ", repr(x.where), ")");
 }
 
-variant OSError (GenericOSError);
+variant OSError;
 
 instance Exception (OSError);
+
+instance OSError (GenericOSError);
 
 [T when VariantMember?(OSError, T)]
 overload Exception(forward x:T) = Exception(OSError(x));

--- a/test/lang/variants/4/main.clay
+++ b/test/lang/variants/4/main.clay
@@ -5,7 +5,8 @@ record Human ();
 
 record Dog ();
 
-variant Animal (Human, Dog);
+variant Animal;
+instance Animal (Human, Dog);
 
 define what;
 overload what(x:Human) = "Human";

--- a/test/lang/variants/closed/1/compilererr.txt
+++ b/test/lang/variants/closed/1/compilererr.txt
@@ -1,0 +1,1 @@
+cannot add instances to closed variant

--- a/test/lang/variants/closed/1/main.clay
+++ b/test/lang/variants/closed/1/main.clay
@@ -1,0 +1,9 @@
+record Bar ();
+record Baz ();
+
+variant Foo (Bar);
+
+instance Foo (Baz);
+
+main() {
+}

--- a/test/lang/variants/closed/empty/compilererr.txt
+++ b/test/lang/variants/closed/empty/compilererr.txt
@@ -1,0 +1,1 @@
+cannot add instances to closed variant

--- a/test/lang/variants/closed/empty/main.clay
+++ b/test/lang/variants/closed/empty/main.clay
@@ -1,0 +1,8 @@
+record Bar ();
+
+variant Foo ();
+
+instance Foo (Bar);
+
+main() {
+}


### PR DESCRIPTION
Closed variant cannot be modified with `instance` statement.

Variant is closed if declaration lists members. Example. Open
variant:

```
variant Exception;
instance Exception (IOError);
```

Closed variant:

```
variant Season (Winter, Spring, Summer, Autumn);
instance Season (OffSeason); // compile-time error
```

This patch is necessary to clearly distinguish library variants
that are designed to be extendable (like Exception) from variants
that have fixed number of instances by design (like Maybe).
