### PR TITLE
Provide better diagnostics why module is not found

### DIFF
--- a/compiler/src/error.cpp
+++ b/compiler/src/error.cpp
@@ -250,18 +250,22 @@ void setAbortOnError(bool flag) {
 }
 
 void displayError(llvm::Twine const &msg, llvm::StringRef kind) {
+    string msgString = msg.str();
+    if (msgString.empty() || msgString[msgString.length() - 1] != '\n')
+        msgString += '\n';
+
     Location location = topLocation();
     if (location.ok()) {
         int line, column;
         displayLocation(location, line, column);
         llvm::errs() << location.source->fileName
-            << '(' << line+1 << ',' << column << "): " << kind << ": " << msg << '\n';
+            << '(' << line+1 << ',' << column << "): " << kind << ": " << msgString;
         llvm::errs().flush();
         displayCompileContext();
         displayDebugStack();
     }
     else {
-        llvm::errs() << kind << ": " << msg << '\n';
+        llvm::errs() << kind << ": " << msgString;
     }
 }
 

--- a/compiler/src/loader.cpp
+++ b/compiler/src/loader.cpp
@@ -171,17 +171,42 @@ static PathString toRelativePath2(DottedNamePtr name) {
 }
 
 static PathString locateModule(DottedNamePtr name) {
-    PathString path, relativePath;
+    PathString path;
 
-    relativePath = toRelativePath1(name);
-    if (locateFile(relativePath, path))
+    PathString relativePath1 = toRelativePath1(name);
+    if (locateFile(relativePath1, path))
         return path;
 
-    relativePath = toRelativePath2(name);
-    if (locateFile(relativePath, path))
+    PathString relativePath2 = toRelativePath2(name);
+    if (locateFile(relativePath2, path))
         return path;
 
-    error(name, "module not found: " + toKey(name));
+    string s;
+    llvm::raw_string_ostream ss(s);
+
+    ss << "module not found: " + toKey(name) << "\n";
+
+    ss << "tried relative paths:\n";
+    ss << "    " << relativePath1 << "\n";
+    ss << "    " << relativePath2 << "\n";
+
+    ss << "with suffixes:\n";
+    for (vector<llvm::SmallString<32> >::const_iterator entry = moduleSuffixes.begin();
+            entry != moduleSuffixes.end(); ++entry)
+    {
+        ss << "    " << *entry << "\n";
+    }
+
+    ss << "in search path:\n";
+    for (vector<PathString>::const_iterator entry = searchPath.begin();
+            entry != searchPath.end(); ++entry)
+    {
+        ss << "    " << *entry << "\n";
+    }
+
+    ss.flush();
+
+    error(name, s);
     llvm_unreachable("module not found");
 }
 


### PR DESCRIPTION
Output may look like this:

```
###############################
import foo.bar.*;
-------^

main() {
###############################
./tmp.clay(1,7): error: module not found: foo.bar
tried relative paths:
    foo/bar/bar
    foo/bar
with suffixes:
    .macosx.x86.64.clay
    .macosx.x86.clay
    .macosx.64.clay
    .x86.64.clay
    .macosx.clay
    .x86.clay
    .64.clay
    .unix.clay
    .clay
in search path:
    /Users/yozh/devel/clay/lib-clay
    /Users/yozh/devel/clay/build/compiler/src/../../../lib-clay
    /Users/yozh/devel/clay/build/compiler/src/../lib/lib-clay
    /Users/yozh/devel/clay/build/compiler/src/lib-clay
    .
```
