### PR TITLE
Prohibit overloads of standalone functions

### DIFF
--- a/compiler/clay.hpp
+++ b/compiler/clay.hpp
@@ -1991,6 +1991,8 @@ struct Overload : public TopLevelItem {
 
 struct Procedure : public TopLevelItem {
     OverloadPtr interface;
+
+    OverloadPtr singleOverload;
     vector<OverloadPtr> overloads;
     ObjectTablePtr evaluatorCache; // HACK: used only for predicates
     ProcedureMono mono;

--- a/compiler/loader.cpp
+++ b/compiler/loader.cpp
@@ -486,6 +486,10 @@ poly:
 }
 
 void addProcedureOverload(ProcedurePtr proc, EnvPtr env, OverloadPtr x) {
+    if (!!proc->singleOverload && proc->singleOverload != x) {
+        // TODO: points to wrong line
+        error(x->location, "standalone functions cannot be overloaded");
+    }
     proc->overloads.insert(proc->overloads.begin(), x);
     getProcedureMonoTypes(proc->mono, env,
         x->code->formalArgs,

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2404,6 +2404,8 @@ static bool llvmProcedure(vector<TopLevelItemPtr> &x) {
     v->location = location;
     x.push_back(v.ptr());
 
+    u->singleOverload = v;
+
     return true;
 }
 
@@ -2473,6 +2475,9 @@ static bool procedureWithBody(vector<TopLevelItemPtr> &x) {
     OverloadPtr oload = new Overload(target, code, callByName, isInline);
     oload->location = location;
     x.push_back(oload.ptr());
+
+    proc->singleOverload = oload;
+
     return true;
 }
 

--- a/lib-clay/algorithms/algorithms.clay
+++ b/lib-clay/algorithms/algorithms.clay
@@ -16,8 +16,10 @@ private getNext(iter) {
     return forward ..getValue(move(value));
 }
 
+define reduce;
+
 [F, A when Sequence?(A)]
-reduce(f:F, a:A) {
+overload reduce(f:F, a:A) {
     var iter = iterator(a);
     var result = getNext(iter);
     for (x in iter)
@@ -114,7 +116,9 @@ overload max(a:A) = forward select(a, greaterEquals?);
 
 /// @section  findIf, reverseFindIf 
 
-findIf(seq, pred) {
+define findIf;
+
+overload findIf(seq, pred) {
     return findIf(begin(seq), end(seq), pred);
 }
 
@@ -125,7 +129,9 @@ overload findIf(_first, _last, pred) {
     return cur;
 }
 
-reverseFindIf(seq, pred) {
+define reverseFindIf;
+
+overload reverseFindIf(seq, pred) {
     return reverseFindIf(begin(seq), end(seq), pred);
 }
 
@@ -222,8 +228,11 @@ in?(seq, elem) = find(seq, elem) != end(seq);
 
 /// @section  beginsWith?, endsWith? 
 
+define beginsWith?;
+define endsWith?;
+
 [A, B when Sequence?(A) and Sequence?(B) and (SequenceElementType(A) == SequenceElementType(B))]
-beginsWith?(seq:A, prefix:B) =
+overload beginsWith?(seq:A, prefix:B) =
     (size(seq) >= size(prefix)) and (slicedUpto(seq, size(prefix)) == prefix);
 
 [A, T when Sequence?(A) and (T == SequenceElementType(A))]
@@ -232,7 +241,7 @@ overload beginsWith?(seq:A, x:T) =
 
 
 [A, B when Sequence?(A) and Sequence?(B) and (SequenceElementType(A) == SequenceElementType(B))]
-endsWith?(seq:A, suffix:B) =
+overload endsWith?(seq:A, suffix:B) =
     (size(seq) >= size(suffix))
     and (slicedFrom(seq, size(seq)-size(suffix)) == suffix);
 
@@ -313,18 +322,22 @@ overload join(sep:S, a:A) = ..join(array(sep), a);
 
 /// @section  binarySearch, binarySearchLowerBound, binarySearchUpperBound 
 
+define binarySearch;
+define binarySearchLowerBound;
+define binarySearchUpperBound;
+
 [A when Sequence?(A)]
-binarySearch(a:A, x) {
+overload binarySearch(a:A, x) {
     return ..binarySearch(begin(a), end(a), x);
 }
 
 [A when Sequence?(A)]
-binarySearchLowerBound(a:A, x) {
+overload binarySearchLowerBound(a:A, x) {
     return binarySearchLowerBound(begin(a), end(a), x);
 }
 
 [A when Sequence?(A)]
-binarySearchUpperBound(a:A, x) {
+overload binarySearchUpperBound(a:A, x) {
     return binarySearchUpperBound(begin(a), end(a), x);
 }
 
@@ -366,7 +379,9 @@ sortBy(a, comparator : C) {
     introsort.introSort(a, (x, y) -> lesser?(comparator, x, y));
 }
 
-sort(a){
+define sort;
+
+overload sort(a){
   sortBy(a, natural());
 }
 

--- a/lib-clay/algorithms/introsort/introsort.clay
+++ b/lib-clay/algorithms/introsort/introsort.clay
@@ -1,6 +1,8 @@
 import algorithms.heaps.*;
 
-introSort(a, compareLess?) {
+define introSort;
+
+overload introSort(a, compareLess?) {
     introSort(begin(a), end(a), compareLess?);
 }
 
@@ -91,7 +93,9 @@ finalInsertionSort(first_, last_, compareLess?) {
     }
 }
 
-insertionSort(a, compareLess?) {
+define insertionSort;
+
+overload insertionSort(a, compareLess?) {
     insertionSort(begin(a), end(a), compareLess?);
 }
 
@@ -145,7 +149,9 @@ moveBackward(first_, last_, newLast_) {
     }
 }
 
-heapSort(a) {
+define heapSort;
+
+overload heapSort(a) {
     heapSort(begin(a), end(a));
 }
 

--- a/lib-clay/algorithms/strings/strings.clay
+++ b/lib-clay/algorithms/strings/strings.clay
@@ -4,10 +4,15 @@ import vectors.*;
 
 /// @section  trim, trimBegin, trimEnd 
 
-trim(seq, pred) = Vector(trimmed(seq, pred));
+define trim;
+define trimBegin;
+define trimEnd;
 
-trimBegin(seq, pred) = Vector(beginTrimmed(seq, pred));
-trimEnd(seq, pred) = Vector(endTrimmed(seq, pred));
+
+overload trim(seq, pred) = Vector(trimmed(seq, pred));
+
+overload trimBegin(seq, pred) = Vector(beginTrimmed(seq, pred));
+overload trimEnd(seq, pred) = Vector(endTrimmed(seq, pred));
 
 
 [S when String?(S)]
@@ -23,16 +28,20 @@ overload trimEnd(seq:S) = trimEnd(seq, asciiSpace?);
 
 /// @section  trimmed, beginTrimmed, endTrimmed 
 
-trimmed(seq, pred) = beginTrimmed(endTrimmed(seq, pred), pred);
+define trimmed;
+define beginTrimmed;
+define endTrimmed;
 
-beginTrimmed(seq, pred) {
+overload trimmed(seq, pred) = beginTrimmed(endTrimmed(seq, pred), pred);
+
+overload beginTrimmed(seq, pred) {
     var b, e = begin(seq), end(seq);
     while ((b != e) and pred(b^))
         inc(b);
     return coordinateRange(b, e);
 }
 
-endTrimmed(seq, pred) {
+overload endTrimmed(seq, pred) {
     var b, e = begin(seq), end(seq);
     while ((b != e) and pred((e-1)^))
         dec(e);

--- a/lib-clay/byteorder/byteorder.x86.64.clay
+++ b/lib-clay/byteorder/byteorder.x86.64.clay
@@ -3,7 +3,7 @@ public import byteorder.platform.*;
 public import byteorder.common.*;
 
 [I32 when inValues?(I32, Int32, UInt32)]
-overload networkToHost(n:I32) --> returned:I32 __llvm__ {
+overload reverseBytes(n:I32) --> returned:I32 __llvm__ {
     %nn = load $I32 * %n
     %rr = call $I32 asm "bswapl $0", "=r,r"($I32 %nn)
     store $I32 %rr, $I32 * %returned
@@ -11,7 +11,7 @@ overload networkToHost(n:I32) --> returned:I32 __llvm__ {
 }
 
 [I64 when inValues?(I64, Int64, UInt64)]
-overload networkToHost(n:I64) --> returned:I64 __llvm__ {
+overload reverseBytes(n:I64) --> returned:I64 __llvm__ {
     %nn = load $I64 * %n
     %rr = call $I64 asm "bswapq $0", "=r,r"($I64 %nn)
     store $I64 %rr, $I64 * %returned

--- a/lib-clay/cocoa/objc/objc.clay
+++ b/lib-clay/cocoa/objc/objc.clay
@@ -133,12 +133,15 @@ private retain(x) {
 
 /// @section  object references 
 
-ObjectType?(T) = false;
+define ObjectType?;
+define nil;
+
+overload ObjectType?(T) = false;
 
 [O when ObjectType?(O)] overload objectHandle(x: O) : ObjectHandle = x.__handle__;
 [O when ObjectType?(O)] overload ObjectParameterType(#O) = O;
 
-[O when ObjectRef?(O)] nil(#O) = O();
+[O when ObjectRef?(O)] overload nil(#O) = O();
 [O when ObjectRef?(O)] nil?(obj: O) = null?(obj.__handle__);
 
 [O when ObjectType?(O)] overload O() = O(nilHandle);
@@ -292,7 +295,8 @@ ClassInstanceVars(#T) = [];
 define ClassClassMethods;
 define ClassInstanceMethods;
 
-MangledModuleChar(c) = stringLiteralFromChars(c);
+define MangledModuleChar;
+overload MangledModuleChar(c) = stringLiteralFromChars(c);
 overload MangledModuleChar(#'.') = "__";
 
 MangledModuleName(T) = cat(..mapValues(
@@ -300,26 +304,29 @@ MangledModuleName(T) = cat(..mapValues(
     ..stringLiteralStaticChars(ModuleName(T))
 ));
 
+define ClassName;
 [T when ClayClass?(T)]
 overload ClassName(#T) = "clay__" ++ MangledModuleName(T) ++ "__" ++ StaticName(T);
 
 [T when ExternalClass?(T) or ExternalClayClass?(T)]
-ClassName(#T) = StaticName(T);
+overload ClassName(#T) = StaticName(T);
 
 define ClassStaticName;
 
 [T when CallDefined?(ClassStaticName, Static[T])]
 overload ClassName(#T) = StaticName(ClassStaticName(T));
 
+define ClassIvarType;
 [T, name when Class?(T) and SuperclassType(T) != Void and StringLiteral?(name)]
-ClassIvarType(#T, #name) = ClassIvarType(SuperclassType(T), name);
+overload ClassIvarType(#T, #name) = ClassIvarType(SuperclassType(T), name);
 [T, name when Class?(T) and StringLiteral?(name) and assocValue?(name, ..ClassInstanceVars(T))]
 overload ClassIvarType(#T, #name) = firstValue(..assocValue(name, ..ClassInstanceVars(T)));
 
 ClassIvarNames(T) = ..mapValues(ivar => ivar.0, ..ClassInstanceVars(T));
 ClassIvarTypes(T) = ..mapValues(ivar => ivar.1, ..ClassInstanceVars(T));
 
-ClassInstanceVar?(T, ivar) = false;
+define ClassInstanceVar?;
+overload ClassInstanceVar?(T, ivar) = false;
 [T, ivar when Class?(T) and StringLiteral?(ivar)]
 overload ClassInstanceVar?(#T, #ivar) = ClassInstanceVar?(SuperclassType(T), ivar);
 [T, ivar when Class?(T) and StringLiteral?(ivar) and assocValue?(ivar, ..ClassInstanceVars(T))]
@@ -337,8 +344,10 @@ define classObjcName;
 
 ValidSuperclass?(T) = Class?(T) or T == Void;
 
+define externalClass;
+
 [Super when ValidSuperclass?(Super)]
-externalClass(#Super) = recordWithProperties(
+overload externalClass(#Super) = recordWithProperties(
     [
         [SuperclassType, Super],
         [ExternalClass?, #true],
@@ -386,8 +395,10 @@ overload objcInitIvarOffset(#T, ivarName)
 ClayClass?(T) = false;
 ExternalClayClass?(T) = false;
 
+define newClass;
+
 [Super, IV, CM, IM] // XXX when ValidSuperclass?(Super)]
-newClass(#Super,
+overload newClass(#Super,
     instancevars: InstanceVars[IV],
     classmethods: ClassMethods[CM],
     instancemethods: InstanceMethods[IM]
@@ -672,8 +683,9 @@ selectorHandle(sel) = objcSelector[sel];
 [sel when Selector?(sel)]
 SelectorArgumentCount(#sel) = countValues(..GenericSelector(sel)) - 1;
 
+define GenericSelector;
 [sel when FixedSelector?(sel)]
-GenericSelector(#sel) = ..selector(sel);
+overload GenericSelector(#sel) = ..selector(sel);
 [sel when VarargSelector?(sel)]
 overload GenericSelector(#sel) = ..varargSelector(sel);
 
@@ -681,8 +693,9 @@ overload GenericSelector(#sel) = ..varargSelector(sel);
 
 /// @section  typed selectors 
 
+define TypedSelector;
 [T, sel when ExternalClass?(T) and FixedSelector?(sel)]
-TypedSelector(#T, #sel) = ..externalInstanceMethod(T, sel);
+overload TypedSelector(#T, #sel) = ..externalInstanceMethod(T, sel);
 [T, sel when ExternalClass?(T) and FixedSelector?(sel)]
 overload TypedSelector(#Static[T], #sel) = ..externalClassMethod(T, sel);
 [T, sel when ClayClass?(T) and FixedSelector?(sel)]
@@ -692,8 +705,9 @@ overload TypedSelector(#T, #sel)
 overload TypedSelector(#Static[T], #sel)
     = ..restValues(..assocValue(sel, ..ClassClassMethods(T)));
 
+define TypedSelector?;
 [T, sel when ExternalClass?(T) and FixedSelector?(sel)]
-TypedSelector?(#T, #sel)
+overload TypedSelector?(#T, #sel)
     = CallDefined?(externalInstanceMethod, Static[T], Static[sel]);
 [T, sel when ExternalClass?(T) and FixedSelector?(sel)]
 overload TypedSelector?(#Static[T], #sel)
@@ -722,8 +736,9 @@ overload TypedSelector?(#Static[T], #sel)
 
 /// @section  selector signatures by type 
 
+private define Selector;
 [sel when Selector?(sel)]
-private Selector(#Id, #sel) = ..GenericSelector(sel);
+overload Selector(#Id, #sel) = ..GenericSelector(sel);
 
 [T, sel when Class?(T) and Selector?(sel)]
 overload Selector(#T, #sel) = ..GenericSelector(sel);
@@ -746,8 +761,10 @@ overload Selector(#Static[T], #sel) = ..Selector(Static[SuperclassType(T)], sel)
 ]
 overload Selector(#Static[T], #sel) = ..TypedSelector(Static[T], sel);
 
+define SelectorReturnType;
+
 [T, sel]
-SelectorReturnType(#T, #sel) = firstValue(..Selector(T, sel));
+overload SelectorReturnType(#T, #sel) = firstValue(..Selector(T, sel));
 
 [T, sel]
 SelectorArgumentTypes(#T, #sel) = ..restValues(..Selector(T, sel));
@@ -756,14 +773,18 @@ SelectorArgumentTypes(#T, #sel) = ..restValues(..Selector(T, sel));
 
 /// @section  retaining and forwarding selectors 
 
-AllocatingSelector?(sel) = false;
+define AllocatingSelector?;
+
+overload AllocatingSelector?(sel) = false;
 [sel when
     stringLiteralStartsWith?(sel, "alloc")
     or stringLiteralStartsWith?(sel, "new")
 ]
 overload AllocatingSelector?(#sel) = true;
 
-RetainingSelector?(sel) = false;
+define RetainingSelector?;
+
+overload RetainingSelector?(sel) = false;
 [sel when
     stringLiteralStartsWith?(sel, "copy")
     or stringLiteralStartsWith?(sel, "mutableCopy")
@@ -771,11 +792,14 @@ RetainingSelector?(sel) = false;
 ]
 overload RetainingSelector?(#sel) = true;
 
-ForwardingSelector?(sel) = false;
+define ForwardingSelector?;
+
+overload ForwardingSelector?(sel) = false;
 [sel when stringLiteralStartsWith?(sel, "init")]
 overload ForwardingSelector?(#sel) = true;
 
-AutoreleasingSelector?(sel) = false;
+define AutoreleasingSelector?;
+overload AutoreleasingSelector?(sel) = false;
 overload AutoreleasingSelector?("autorelease") = true;
 
 [T, sel when Class?(T) and AllocatingSelector?(sel)]
@@ -792,14 +816,15 @@ overload SelectorReturnType(#T, #sel) = T;
 
 /// @section  argument conversion 
 
-ObjectRef?(T) = false;
+define ObjectRef?;
+overload ObjectRef?(T) = false;
 [T when ObjectType?(T)]
 overload ObjectRef?(#T) = true;
 [T when ObjectType?(T)]
 overload ObjectRef?(#Retained[T]) = true;
 
-MsgSendCompatible?(ParamType, ValueType) = false;
-
+define MsgSendCompatible?;
+overload MsgSendCompatible?(ParamType, ValueType) = false;
 [T] overload MsgSendCompatible?(#T, #T) = true;
 
 [Param, Value when
@@ -821,7 +846,8 @@ overload MsgSendCompatible?(#Retained[Id], #Value) = true;
 
 // XXX selector container
 
-MsgSendParamType(Param) = Param;
+define MsgSendParamType;
+overload MsgSendParamType(Param) = Param;
 
 [Param when ObjectRef?(Param)]
 overload MsgSendParamType(#Param) = ObjectHandle;
@@ -829,19 +855,22 @@ overload MsgSendParamType(#Param) = ObjectHandle;
 overload MsgSendParamType(#Void) = #[];
 overload MsgSendParamType(#Bool) = BOOL;
 
+/* private */ define msgSendUnbox1;
 [Param]
-/*private*/ msgSendUnbox1(#Param, forward x: Param) = forward x;
+overload msgSendUnbox1(#Param, forward x: Param) = forward x;
 [Param, Value when ObjectRef?(Param)]
 overload msgSendUnbox1(#Param, forward x: Value) = objectHandle(x);
 
 overload msgSendUnbox1(#Bool, forward x: Bool) = if (x) BOOL(1) else BOOL(0);
 
-private varArgUnbox1(forward x) = forward x;
+private define varArgUnbox1;
+overload varArgUnbox1(forward x) = forward x;
 [Param when ObjectRef?(Param)]
 overload varArgUnbox1(forward x: Param) = objectHandle(x);
 
+/*XXX private*/ define msgSendUnbox;
 [T, S when FixedSelector?(S)]
-/*XXX private*/ msgSendUnbox(#T, #S, forward ..args)
+overload msgSendUnbox(#T, #S, forward ..args)
     = forward ..mapValues2(msgSendUnbox1, #SelectorArgumentCount(S),
         ..SelectorArgumentTypes(T, S),
         ..args
@@ -855,8 +884,9 @@ overload msgSendUnbox(#T, #S, forward ..args) {
 }
 
 
+/*XXX private*/ define msgSendBox1;
 [Return]
-/*XXX private*/ msgSendBox1(#Return, forward x: Return) = forward x;
+overload msgSendBox1(#Return, forward x: Return) = forward x;
 
 overload msgSendBox1(#Void) = ;
 
@@ -886,24 +916,29 @@ SelectorTypeEncoding(T, S)
 
 /// @section  message sending 
 
+private define objc_msgSend_for;
 [T, S when Selector?(S)]
-private objc_msgSend_for(#T, #S) = objc_msgSend;
+overload objc_msgSend_for(#T, #S) = objc_msgSend;
 [T, S when Selector?(S) and StRet?(SelectorReturnParamType(T, S))]
 overload objc_msgSend_for(#T, #S) = objc_msgSend_stret;
 [T, S when Selector?(S) and FpRet?(SelectorReturnParamType(T, S))]
 overload objc_msgSend_for(#T, #S) = objc_msgSend_fpret;
 
+private define objc_msgSendSuper_for;
 [T, S when Selector?(S)]
-private objc_msgSendSuper_for(#T, #S) = objc_msgSendSuper;
+overload objc_msgSendSuper_for(#T, #S) = objc_msgSendSuper;
 [T, S when Selector?(S) and StRet?(SelectorReturnParamType(T, S))]
 overload objc_msgSendSuper_for(#T, #S) = objc_msgSendSuper_stret;
 
+private define class_getMethodImplementation_for;
 [T, S when Selector?(S)]
-private class_getMethodImplementation_for(#T, #S) = class_getMethodImplementation;
+overload class_getMethodImplementation_for(#T, #S) = class_getMethodImplementation;
 [T, S when Selector?(S) and StRet?(SelectorReturnParamType(T, S))]
 overload class_getMethodImplementation_for(#T, #S) = class_getMethodImplementation_stret;
 
-SelectorCallableWith?(C, S, ..T) = false;
+define SelectorCallableWith?;
+
+overload SelectorCallableWith?(C, S, ..T) = false;
 
 [C, S, ..TT when FixedSelector?(S) and countValues(..TT) == SelectorArgumentCount(S)]
 overload SelectorCallableWith?(#C, #S, ..T: TT)
@@ -923,8 +958,10 @@ private _SelectorCallableWith?(C, S, ..T) {
     return true;
 }
 
+define SelectorImpType;
+
 [C, S when FixedSelector?(S)]
-SelectorImpType(#C, #S) = CCodePointer[
+overload SelectorImpType(#C, #S) = CCodePointer[
         [ObjectHandle, SelectorHandle, ..SelectorArgumentParamTypes(C, S)],
         SelectorReturnParamType(C, S)
     ];
@@ -938,8 +975,10 @@ overload SelectorImpType(#C, #S) = VarArgsCCodePointer[
 private msgSender(C, S)
     = SelectorImpType(C, S)(objc_msgSend_for(C, S));
 
+private define msgSenderSuper;
+
 [C, S when FixedSelector?(S)]
-private msgSenderSuper(#C, #S)
+overload msgSenderSuper(#C, #S)
     = CCodePointer[
         [Pointer[ObjcSuper], SelectorHandle, ..SelectorArgumentParamTypes(C, S)],
         SelectorReturnParamType(C, S)
@@ -965,11 +1004,13 @@ msgSend(#SelfT, imp, self, #S, forward ..args: T) {
 
 /// @section  identifier-selector conversion 
 
-private _identifierSelectorChar(c) = stringLiteralFromChars(c);
+private define _identifierSelectorChar;
+overload _identifierSelectorChar(c) = stringLiteralFromChars(c);
 overload _identifierSelectorChar(#'_') = ":";
 
+private define _extraColon;
 [argCount, underscoreCount, lastCharacter]
-private _extraColon(#argCount, #underscoreCount, #lastCharacter) = ;
+overload _extraColon(#argCount, #underscoreCount, #lastCharacter) = ;
 [argCount, underscoreCount, lastCharacter when
     argCount > underscoreCount
     and lastCharacter != '_'
@@ -1019,8 +1060,10 @@ overload fieldRef(forward self: T, #cmd)
 [T, cmd when Class?(T) and ValidMethodIdentifier?(cmd)]
 overload fieldRef(#T, #cmd) = MethodRef(Static[T], T, cmd);
 
+define callMethod;
+
 [T, selector, ..Args when ObjectParameterType?(T) and Selector?(selector)]
-callMethod(forward self: T, #selector, forward ..args: Args)
+overload callMethod(forward self: T, #selector, forward ..args: Args)
     = forward ..msgSend(
         T,
         msgSender(T, selector),
@@ -1098,8 +1141,10 @@ overload fieldRef(ivars: IvarsRef[T], #ivar)
 
 private record SuperRef[T, Captured] (__self__: Captured);
 
+define super;
+
 [T when Class?(T) and SuperclassType(T) != Void]
-super(forward obj: T) = SuperRef[T, Type(captureValue(obj))](captureValue(obj));
+overload super(forward obj: T) = SuperRef[T, Type(captureValue(obj))](captureValue(obj));
 
 [T when Class?(T) and SuperclassType(T) != Void]
 overload super(forward obj: Retained[T]) = SuperRef[T, Type(captureValue(obj))](captureValue(obj));

--- a/lib-clay/cocoa/objc/platform/platform.arm.clay
+++ b/lib-clay/cocoa/objc/platform/platform.arm.clay
@@ -1,7 +1,10 @@
 import cocoa.objc.runtime.(Class);
 
-FpRet?(type) = false;
-StRet?(type) = false;
+define FpRet?;
+deinfe StRet?;
+
+overload FpRet?(type) = false;
+overload StRet?(type) = false;
 //Fp2Ret?(type) = false;
 
 // XXX not tested!

--- a/lib-clay/cocoa/objc/platform/platform.x86.32.clay
+++ b/lib-clay/cocoa/objc/platform/platform.x86.32.clay
@@ -1,7 +1,10 @@
 import cocoa.objc.runtime.(Class);
 
-FpRet?(type) = false;
-StRet?(type) = false;
+define FpRet?;
+define StRet?;
+
+overload FpRet?(type) = false;
+overload StRet?(type) = false;
 //Fp2Ret?(type) = false;
 
 overload FpRet?(#Float32) = true;

--- a/lib-clay/cocoa/objc/platform/platform.x86.64.clay
+++ b/lib-clay/cocoa/objc/platform/platform.x86.64.clay
@@ -1,7 +1,10 @@
 import cocoa.objc.runtime.(Class);
 
-FpRet?(type) = false;
-StRet?(type) = false;
+define FpRet?;
+define StRet?;
+
+overload FpRet?(type) = false;
+overload StRet?(type) = false;
 //Fp2Ret?(type) = false;
 
 //overload FpRet?(#Float80) = true;

--- a/lib-clay/cocoa/util/util.clay
+++ b/lib-clay/cocoa/util/util.clay
@@ -64,8 +64,9 @@ overload cstring(o: O) = o.UTF8String();
 
 
 /// @section  NSValue overloads 
+define makeNSValue;
 [T]
-makeNSValue(value: T)
+overload makeNSValue(value: T)
     = NSValue.valueWithBytes_objCType(RawPointer(@value), cstring(encode(T)));
 [T when ObjectRef?(T)]
 overload makeNSValue(obj: T) = NSValue.valueWithNonretainedObject(obj);
@@ -81,8 +82,10 @@ fromNSValue(#T, o: O) {
         return fromNSValueUnsafe(T, o);
 }
 
+define fromNSValueUnsafe;
+
 [T, O when ObjectRef?(O)]
-fromNSValueUnsafe(#T, o: O) --> returned: T {
+overload fromNSValueUnsafe(#T, o: O) --> returned: T {
     o.getValue(RawPointer(@returned));
 }
 
@@ -209,7 +212,8 @@ makeNSArray(forward ..elements: E)
 makeNSMutableArray(forward ..elements: E)
     = makeArrayOfClass(NSMutableArray, ..elements);
 
-private swapValuePairs() = ;
+private define swapValuePairs;
+overload swapValuePairs() = ;
 overload swapValuePairs(forward x, forward y, forward ..xys)
     = forward y, x, ..swapValuePairs(..xys);
 
@@ -288,7 +292,9 @@ initObjectWith(
     return self;
 }
 
-initObject(self) = initObjectWith(self, "init", self => self);
+define initObject;
+
+overload initObject(self) = initObjectWith(self, "init", self => self);
 
 overload initObject(self, superSelector, forward ..args)
     = initObjectWith(self, superSelector, initObjectMembers, ..args);
@@ -297,8 +303,10 @@ overload initObject(self, superSelector, forward ..args)
 private objectMembers(self: O)
     = ref ..mapValues(ivar => ref fieldRef(self^, ivar.0), ..ClassInstanceVars(O));
 
+define initObjectMembers;
+
 [O when Class?(O)]
-initObjectMembers(self: O) {
+overload initObjectMembers(self: O) {
     ..for (member in objectMembers(self))
         member <-- Type(member)();
     return self;
@@ -337,8 +345,10 @@ deallocObject(self: O) {
 
 /// @section  templates to define lifecycle methods 
 
+define AutoreleasedClassMethod;
+
 [selector when Selector?(selector)]
-AutoreleasedClassMethod(#selector)
+overload AutoreleasedClassMethod(#selector)
     = [selector, class => class.alloc().init().autorelease()];
 
 [selector, instanceSelector when Selector?(selector) and Selector?(instanceSelector)]
@@ -347,8 +357,10 @@ overload AutoreleasedClassMethod(#selector, #instanceSelector)
         callMethod(class.alloc(), instanceSelector, ..args).autorelease()
     ];
 
+define InitInstanceMethod;
+
 [selector, superSelector when Selector?(selector) and Selector?(superSelector)]
-InitInstanceMethod(#selector, #superSelector, ..Types)
+overload InitInstanceMethod(#selector, #superSelector, ..Types)
     = [selector, (self, ..args) => initObject(self, superSelector, ..args), ..Types];
 
 overload InitInstanceMethod(selector) = InitInstanceMethod(selector, "init");
@@ -359,8 +371,10 @@ define CopyRoot;
 define CopyInheriting;
 define CopyImmutable;
 
+define CopyInstanceMethod;
+
 [selector when Selector?(selector)]
-CopyInstanceMethod(#selector, #CopyRoot)
+overload CopyInstanceMethod(#selector, #CopyRoot)
     = [selector, copyRootObject];
 [selector when Selector?(selector)]
 overload CopyInstanceMethod(#selector, #CopyInheriting)
@@ -373,14 +387,18 @@ overload CopyInstanceMethod(#selector, #CopyImmutable)
 overload CopyInstanceMethod(#Flag)
     = CopyInstanceMethod("copyWithZone:", Flag);
 
+define DeallocInstanceMethod;
+
 [selector when Selector?(selector)]
-DeallocInstanceMethod(#selector) = [selector, deallocObject];
+overload DeallocInstanceMethod(#selector) = [selector, deallocObject];
 
 overload DeallocInstanceMethod() = DeallocInstanceMethod("dealloc");
 
 
+define ReaderInstanceMethod;
+
 [ivarName, readerSelector when StringLiteral?(ivarName) and Selector?(readerSelector)]
-ReaderInstanceMethod(#ivarName, #readerSelector, T)
+overload ReaderInstanceMethod(#ivarName, #readerSelector, T)
     = [readerSelector, self => T(fieldRef(self^, ivarName)), T];
 
 [ivarName when StringLiteral?(ivarName) and Selector?(ivarName)]
@@ -399,8 +417,10 @@ overload ReaderInstanceMethod(#ivarName)
 defaultWriterSelector(ivarName)
     = "set" ++ stringLiteralCapitalize(ivarName) ++ ":";
 
+define WriterInstanceMethod;
+
 [ivarName, writerSelector when StringLiteral?(ivarName) and Selector?(writerSelector)]
-WriterInstanceMethod(#ivarName, #writerSelector, T)
+overload WriterInstanceMethod(#ivarName, #writerSelector, T)
     = [writerSelector, (self, value) => { fieldRef(self^, ivarName) = value; }, Void, T];
 
 [ivarName when StringLiteral?(ivarName) and Selector?(defaultWriterSelector(ivarName))]
@@ -416,12 +436,14 @@ overload WriterInstanceMethod(#ivarName)
     = WriterInstanceMethod(ivarName, defaultWriterSelector(ivarName));
 
 
+define PropertyInstanceMethods;
+
 [ivarName, readerSelector, writerSelector when
     StringLiteral?(ivarName)
     and Selector?(readerSelector)
     and Selector?(writerSelector)
 ]
-PropertyInstanceMethods(#ivarName, #readerSelector, #writerSelector, T)
+overload PropertyInstanceMethods(#ivarName, #readerSelector, #writerSelector, T)
     = ReaderInstanceMethod(ivarName, readerSelector, T),
       WriterInstanceMethod(ivarName, writerSelector, T);
 
@@ -501,7 +523,8 @@ private regularClassInstanceMethods(..fields)
       DeallocInstanceMethod(),
       ..regularClassPropertyMethods(..fields);
 
-private regularClassInitMethod() = ;
+private define regularClassInitMethod;
+overload regularClassInitMethod() = ;
 overload regularClassInitMethod(..fields)
     = InitInstanceMethod(regularClassInitMethodName(..fields), "init",
         Id, ..mapValues(x => x.1, ..fields)

--- a/lib-clay/commandline/dispatch/dispatch.clay
+++ b/lib-clay/commandline/dispatch/dispatch.clay
@@ -38,8 +38,10 @@ private usage(..commandTuples) {
 }
 
 
+private define commandName;
+
 [fn when CallDefined?(fn, Vector[String])]
-private commandName(#fn) = StaticName(fn);
+overload commandName(#fn) = StaticName(fn);
 
 [fn, ..Description when CallDefined?(fn, Vector[String])]
 overload commandName(commandTuple: Tuple[Static[fn], ..Description])
@@ -53,8 +55,10 @@ overload commandName(commandTuple: Tuple[Static[fn], ..Description])
 overload commandName(commandTuple: Tuple[Name, Callable, ..Description])
     = commandTuple.0;
 
+private define commandFunction;
+
 [fn when CallDefined?(fn, Vector[String])]
-private commandFunction(#fn) = fn;
+overload commandFunction(#fn) = fn;
 
 [fn, ..Description when CallDefined?(fn, Vector[String])]
 overload commandFunction(commandTuple: Tuple[Static[fn], ..Description])
@@ -68,8 +72,10 @@ overload commandFunction(commandTuple: Tuple[Static[fn], ..Description])
 overload commandFunction(commandTuple: Tuple[Name, Callable, ..Description])
     = commandTuple.1;
 
+private define commandDescription;
+
 [fn when CallDefined?(fn, Vector[String])]
-private commandDescription(#fn)
+overload commandDescription(#fn)
     = ;
 
 [fn, ..Description when CallDefined?(fn, Vector[String])]
@@ -87,8 +93,10 @@ overload commandDescription(commandTuple: Tuple[Name, Callable, ..Description])
 private commandTypeReturnCount(T)
     = countValues(..Type(..commandFunction(typeToRValue(T))(Vector[String]())));
 
+private define invokeCommand;
+
 [CommandTuple when commandTypeReturnCount(CommandTuple) == 1]
-private invokeCommand(commandTuple: CommandTuple, args)
+overload invokeCommand(commandTuple: CommandTuple, args)
     = commandFunction(commandTuple)(args);
 
 [CommandTuple when commandTypeReturnCount(CommandTuple) == 0]

--- a/lib-clay/comparators/comparators.clay
+++ b/lib-clay/comparators/comparators.clay
@@ -4,7 +4,9 @@ import sequences.lazy.*;
 // It may be used whenever you might want to naturally be able to redefine
 // operators such as equality or ordering for use in a specific operation
 
-Comparator?(T) = false;
+define Comparator?;
+
+overload Comparator?(T) = false;
 
 forceinline overload notEquals?(comparator, a, b) = not equals?(comparator, a, b);
 forceinline overload ordered?(comparator, a, b) = (a <= b) or (b <= a);
@@ -44,7 +46,8 @@ comparing(f) = Comparing(f);
 record Reversed[C](original : C);
 [C when Comparator?(C)] overload Comparator?(#Reversed[C]) = true;
 
-[C when Comparator?(C)] reversed(c : C) = Reversed(c);
+define reversed;
+[C when Comparator?(C)] overload reversed(c : C) = Reversed(c);
 [C when Comparator?(C)] overload reversed(c : Reversed[C]) = c.original;
 overload reversed() = reversed(natural());
 

--- a/lib-clay/complex/complex.clay
+++ b/lib-clay/complex/complex.clay
@@ -72,7 +72,9 @@ forceinline overload (-)(z:T) = Complex(-real(z),-imag(z));
 forceinline overload (+)(z:T) = z;
 
 [T when Complex?(T)]
-forceinline conj(z:T) = Complex(real(z),-imag(z));
+define conj(z:T);
+
+forceinline overload conj(z) = Complex(real(z),-imag(z));
 
 [T when Imaginary?(T)]
 forceinline overload conj(z:T) = -z;

--- a/lib-clay/complex/core/core.clay
+++ b/lib-clay/complex/core/core.clay
@@ -1,4 +1,6 @@
-[T] Complex?(#T) = false;
+define Complex?;
+
+overload Complex?(T) = false;
 overload Complex?(#Complex32) = true;
 overload Complex?(#Complex64) = true;
 overload Complex?(#Complex80) = true;
@@ -18,10 +20,14 @@ forceinline overload im(z:Complex80) = (Pointer[ILongDouble](@z)+1);
 [C when Complex?(C)]
 forceinline real(z:C) = re(z)^;
 
+
+define imag;
+define imagValue;
+
 [C when Complex?(C)]
-forceinline imag(z:C) = im(z)^;
+forceinline overload imag(z:C) = im(z)^;
 [C when Complex?(C)]
-forceinline imagValue(z:C) = numericConvert(ComplexBaseType(C),im(z)^);
+forceinline overload imagValue(z:C) = numericConvert(ComplexBaseType(C),im(z)^);
 
 [I when Imaginary?(I)]
 forceinline overload imag(z:I) = z;
@@ -29,7 +35,8 @@ forceinline overload imagValue(z:Imag32) = numericConvert(Float32, z);
 forceinline overload imagValue(z:Imag64) = numericConvert(Float64, z);
 forceinline overload imagValue(z:Imag80) = numericConvert(Float80, z);
 
-forceinline Complex(a:Float,b:IFloat) --> r:Complex32 { re(r)^ = a; im(r)^ = b;}
+define Complex;
+forceinline overload Complex(a:Float,b:IFloat) --> r:Complex32 { re(r)^ = a; im(r)^ = b;}
 forceinline overload Complex(a:Double,b:IDouble) --> r:Complex64 { re(r)^ = a; im(r)^ = b;}
 forceinline overload Complex(a:LongDouble,b:ILongDouble) --> r:Complex80 { re(r)^ = a; im(r)^ = b;}
 forceinline overload Complex(a:Float,b:IDouble) --> r:Complex64 { re(r)^ = Double(a); im(r)^ = b;}
@@ -54,16 +61,22 @@ forceinline overload Complex(a:T) = Complex(a,0.f);
 [T when Imaginary?(T)]
 forceinline overload Complex(a:T) = Complex(0.f,a);
 
-ComplexBaseType(#Complex32) = Float;
+[C when Complex?(C)]
+define ComplexBaseType(#C);
+overload ComplexBaseType(#Complex32) = Float;
 overload ComplexBaseType(#Complex64) = Double;
 overload ComplexBaseType(#Complex80) = LongDouble;
 
-[T when Complex?(T)]
-ComplexRealType(#T) = ComplexBaseType(T);
-
-ComplexImagType(#Complex32) = IFloat;
+[C when Complex?(C)]
+define ComplexImagType(#C);
+overload ComplexImagType(#Complex32) = IFloat;
 overload ComplexImagType(#Complex64) = IDouble;
 overload ComplexImagType(#Complex80) = ILongDouble;
+
+define ComplexRealType;
+
+[T when Complex?(T)]
+overload ComplexRealType(#T) = ComplexBaseType(T);
 
 [T when Complex?(T)]
 overload ComplexRealType(z:T) = Type(real(z));
@@ -71,8 +84,10 @@ overload ComplexRealType(z:T) = Type(real(z));
 [T when Complex?(T)]
 overload ComplexImagType(z:T) = Type(imag(z));
 
+define ComplexType;
+
 [T when Complex?(T)]
-ComplexType(#T) = T;
+overload ComplexType(#T) = T;
 
 [T when Float?(T)]
 overload ComplexType(#T) = Type(Complex(T()));

--- a/lib-clay/core/arrays/arrays.clay
+++ b/lib-clay/core/arrays/arrays.clay
@@ -200,8 +200,10 @@ overload destroy(a:Array[T,n]) {
 
 /// @section  array - type inferring constructor 
 
+define array;
+
 [..A when countValues(..A) > 0 and equalValues?(..A)]
-alias array(..args:A) {
+alias overload array(..args:A) {
     return Array[takeValues(#1, ..A), countValues(..A)](..args);
 }
 

--- a/lib-clay/core/characters/characters.clay
+++ b/lib-clay/core/characters/characters.clay
@@ -6,7 +6,10 @@ forceinline overload __operators__.charLiteral(code) = Char(code);
 
 record UniChar (code:UInt32);
 
-Character?(x) : Bool = false;
+[T]
+define Character?(#T) : Bool;
+
+overload Character?(x) : Bool = false;
 overload Character?(#Char) : Bool = true;
 overload Character?(#UniChar) : Bool = true;
 

--- a/lib-clay/core/exceptions/exceptions.clay
+++ b/lib-clay/core/exceptions/exceptions.clay
@@ -44,7 +44,9 @@ private exceptionObject(exp:RawPointer) = ref Pointer[ExceptionData](exp)^;
 // be terminated with \n character. This is very simple implementation
 // that depends on nothing but core. `printer.exception` module contains
 // more sophisticated version.
-printUnhandledExceptionToStderr(e) : {
+define printUnhandledExceptionToStderr(e) :;
+
+overload printUnhandledExceptionToStderr(e) {
     libc.fprintf(libc.stderr, cstring("unhandled %s exception\n"), cstring(MemberTypeName(e)));
 }
 

--- a/lib-clay/core/maybe/maybe.clay
+++ b/lib-clay/core/maybe/maybe.clay
@@ -17,7 +17,9 @@ forceinline overload Maybe[T]() = Maybe[T](Nothing());
 
 forceinline nothing(T) = Maybe[T]();
 
-Maybe?(T) = false;
+[T]
+define Maybe?(#T) : Bool;
+overload Maybe?(T) = false;
 [T] overload Maybe?(#Maybe[T]) : Bool = true;
 
 
@@ -26,8 +28,9 @@ Maybe?(T) = false;
 forceinline nothing?(x) : Bool = variantIs?(x, Nothing);
 forceinline just?(x) : Bool = variantIs?(x, Type(just(x)));
 
+define just;
 [T]
-forceinline just(forward m: Maybe[T]) = forward variantAs(m, T);
+forceinline overload just(forward m: Maybe[T]) = forward variantAs(m, T);
 [T]
 forceinline overload just(m: Maybe[T], dflt: T) = maybe(m, v => v, () => dflt);
 

--- a/lib-clay/core/memory/memory.clay
+++ b/lib-clay/core/memory/memory.clay
@@ -83,8 +83,10 @@ freeRawMemoryAligned(ptr:Pointer[T]) {
 
 /// @section  allocateRawMemory, freeRawMemory 
 
+define allocateRawMemory;
+
 [T,I when Integer?(I)]
-allocateRawMemory(#T, count:I) {
+overload allocateRawMemory(#T, count:I) {
     var ptr = libc.malloc(TypeSize(T) * SizeT(count));
     return Pointer[T](ptr);
 }
@@ -95,8 +97,10 @@ reallocateRawMemory(ptr:Pointer[T], count:I) {
     return Pointer[T](newptr);
 }
 
+define freeRawMemory;
+
 [T]
-freeRawMemory(ptr:Pointer[T]) {
+overload freeRawMemory(ptr:Pointer[T]) {
     libc.free(RawPointer(ptr));
 }
 
@@ -123,8 +127,10 @@ initializeMemory(begin:Pointer[T], end:Pointer[T]) {
 
 /// @section  destroyMemory 
 
+define destroyMemory;
+
 [T when not PODType?(T)]
-destroyMemory(begin:Pointer[T], end:Pointer[T]) {
+overload destroyMemory(begin:Pointer[T], end:Pointer[T]) {
     eachLocation(begin, end, destroy);
 }
 
@@ -132,8 +138,10 @@ destroyMemory(begin:Pointer[T], end:Pointer[T]) {
 
 /// @section  copyNonoverlappingMemory 
 
+define copyNonoverlappingMemory;
+
 [T when not PODType?(T)]
-copyNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
+overload copyNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
     var srcPtr = srcBegin;
     eachLocationWithCleanup(destBegin, destBegin+(srcEnd-srcBegin), x => {
         x <-- srcPtr^;
@@ -144,8 +152,13 @@ copyNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Point
 
 /// @section  move*Memory* 
 
+define moveMemory;
+define moveMemoryUnsafe;
+define moveNonoverlappingMemory;
+define moveNonoverlappingMemoryUnsafe;
+
 [T when not PODType?(T)]
-moveMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
+overload moveMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
     if (destBegin <= srcBegin) {
         moveMemoryForwardsUnsafe(destBegin, srcBegin, srcEnd);
         var destEnd = destBegin + (srcEnd - srcBegin);
@@ -158,7 +171,7 @@ moveMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
 }
 
 [T when not PODType?(T)]
-moveMemoryUnsafe(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
+overload moveMemoryUnsafe(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
     if (destBegin <= srcBegin)
         moveMemoryForwardsUnsafe(destBegin, srcBegin, srcEnd);
     else
@@ -184,7 +197,7 @@ private moveMemoryBackwardsUnsafe(destBegin:Pointer[T], srcBegin:Pointer[T], src
 }
 
 [T when not PODType?(T)]
-moveNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
+overload moveNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
     var srcPtr = srcBegin;
     eachLocation(destBegin, destBegin+(srcEnd-srcBegin), x => {
         x <-- move(srcPtr^);
@@ -193,7 +206,7 @@ moveNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Point
 }
 
 [T when not PODType?(T)]
-moveNonoverlappingMemoryUnsafe(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
+overload moveNonoverlappingMemoryUnsafe(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd:Pointer[T]) {
     moveMemoryForwardsUnsafe(destBegin, srcBegin, srcEnd);
 }
 
@@ -201,8 +214,10 @@ moveNonoverlappingMemoryUnsafe(destBegin:Pointer[T], srcBegin:Pointer[T], srcEnd
 
 /// @section  resetMemoryUnsafe 
 
+define resetMemoryUnsafe;
+
 [T when not PODType?(T)]
-resetMemoryUnsafe(begin:Pointer[T], end:Pointer[T]) {
+overload resetMemoryUnsafe(begin:Pointer[T], end:Pointer[T]) {
     eachLocation(begin, end, resetUnsafe);
 }
 
@@ -226,8 +241,10 @@ zeroObject(o) { zeroMemory(Pointer[UInt8](@o), Pointer[UInt8](@o + 1)); }
 
 /// @section  assignNonoverlappingMemory, moveAssignNonoverlappingMemory 
 
+define assignNonoverlappingMemory;
+
 [T, U when not (T == U and PODType?(T)) and CallDefined?(assign, T, U)]
-assignNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[U], srcEnd:Pointer[U]) {
+overload assignNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[U], srcEnd:Pointer[U]) {
     var srcPtr = srcBegin;
     eachLocation(destBegin, destBegin+(srcEnd-srcBegin), x => {
         x = srcPtr^;
@@ -235,8 +252,10 @@ assignNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[U], srcEnd:Poi
     });
 }
 
+define moveAssignNonoverlappingMemory;
+
 [T, U when not (T == U and PODType?(T)) and CallDefined?(assign, T, U)]
-moveAssignNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[U], srcEnd:Pointer[U]) {
+overload moveAssignNonoverlappingMemory(destBegin:Pointer[T], srcBegin:Pointer[U], srcEnd:Pointer[U]) {
     var srcPtr = srcBegin;
     eachLocation(destBegin, destBegin+(srcEnd-srcBegin), x => {
         x = move(srcPtr^);

--- a/lib-clay/core/numbers/numbers.clay
+++ b/lib-clay/core/numbers/numbers.clay
@@ -3,7 +3,9 @@ import core.platform.(OSFamily, Unix, CPU, X86_64);
 
 /// @section  numeric type predicates 
 
-[T] SignedInteger?(#T) = false;
+[T]
+define SignedInteger?(#T) : Bool;
+overload SignedInteger?(T) = false;
 overload SignedInteger?(#Int8) : Bool = true;
 overload SignedInteger?(#Int16) : Bool = true;
 overload SignedInteger?(#Int32) : Bool = true;
@@ -11,15 +13,17 @@ overload SignedInteger?(#Int64) : Bool = true;
 overload SignedInteger?(#Int128) : Bool = true;
 
 
-[T] UnsignedInteger?(#T) = false;
+[T]
+define UnsignedInteger?(#T) : Bool;
+overload UnsignedInteger?(T) = false;
 overload UnsignedInteger?(#UInt8) : Bool = true;
 overload UnsignedInteger?(#UInt16) : Bool = true;
 overload UnsignedInteger?(#UInt32) : Bool = true;
 overload UnsignedInteger?(#UInt64) : Bool = true;
 overload UnsignedInteger?(#UInt128) : Bool = true;
 
-
-[T] Integer?(#T) : Bool = SignedInteger?(T) or UnsignedInteger?(T);
+define Integer?(..T) : Bool;
+[T] overload Integer?(#T) : Bool = SignedInteger?(T) or UnsignedInteger?(T);
 [A, B] overload Integer?(#A, #B) : Bool = Integer?(A) and Integer?(B);
 
 
@@ -64,11 +68,13 @@ SignedInteger(#I) = SignedIntegerOfSize(#Int(TypeSize(I)));
 UnsignedInteger(#I) = UnsignedIntegerOfSize(#Int(TypeSize(I)));
 
 
-[T] ByteSizedInteger?(#T) : Bool = false;
+[T] define ByteSizedInteger?(#T) : Bool;
+overload ByteSizedInteger?(T) : Bool = false;
 overload ByteSizedInteger?(#Int8) : Bool  = true;
 overload ByteSizedInteger?(#UInt8) : Bool  = true;
 
-[T] Float?(#T) : Bool = false;
+define Float?(..T) : Bool;
+overload Float?(T) : Bool = false;
 overload Float?(#Float32) : Bool  = true;
 overload Float?(#Float64) : Bool  = true;
 overload Float?(#Float80) : Bool  = true;
@@ -79,7 +85,8 @@ overload Float?(#Float80) : Bool  = true;
 BuiltinFloatTypes() = Float32, Float64, Float80;
 
 
-[T] Imaginary?(#T) : Bool = false;
+define Imaginary?(..T) : Bool;
+overload Imaginary?(T) : Bool = false;
 overload Imaginary?(#Imag32) : Bool = true;
 overload Imaginary?(#Imag64) : Bool = true;
 overload Imaginary?(#Imag80) : Bool = true;
@@ -90,7 +97,8 @@ overload Imaginary?(#Imag80) : Bool = true;
 BuiltinImaginaryTypes() = Imag32, Imag64, Imag80;
 
 
-[T] Numeric?(#T) : Bool = Integer?(T) or Float?(T) or Imaginary?(T);
+define Numeric?(..T) : Bool;
+[T] overload Numeric?(#T) : Bool = Integer?(T) or Float?(T) or Imaginary?(T);
 [A, B] overload Numeric?(#A, #B) : Bool = Numeric?(A) and Numeric?(B);
 
 
@@ -156,7 +164,8 @@ forceinline overload wrapToBiggerNumericType(#A, #B, v) : A = wrapCast(A, v);
 [A,B when Numeric?(A,B) and BiggerNumeric?(B,A)]
 forceinline overload wrapToBiggerNumericType(#A, #B, v) : B = wrapCast(B, v);
 
-ImagBaseType(#Imag32) = Float;
+define ImagBaseType;
+overload ImagBaseType(#Imag32) = Float;
 overload ImagBaseType(#Imag64) = Double;
 overload ImagBaseType(#Imag80) = LongDouble;
 
@@ -263,8 +272,10 @@ forceinline inRange?(x,l,u) : Bool =  (<)(x,u) and (<=)(l,x);
 
 forceinline inRangeEquals?(x,l,u) : Bool  =  (<=)(x,u) and (<=)(l,x);
 
-[T when Numeric?(T)]
-forceinline zero?(x:T) : Bool = (==)(x, T(0));
+define zero?;
+
+[T]
+forceinline overload zero?(x:T) : Bool = (==)(x, T(0));
 
 
 
@@ -469,18 +480,25 @@ forceinline overload A(b:B) : A
 
 /// @section  never-checked wrap-on-overflow math 
 
+define wrapAdd;
+define wrapNegate;
+define wrapSubtract;
+define wrapMultiply;
+define wrapQuotient;
+define wrapRemainder;
+
 [A when Integer?(A)]
-forceinline wrapNegate(a:A) : A = numericNegate(a);
+forceinline overload wrapNegate(a:A) : A = numericNegate(a);
 [A when Integer?(A)]
-forceinline wrapAdd(a:A, b:A) : A = numericAdd(a, b);
+forceinline overload wrapAdd(a:A, b:A) : A = numericAdd(a, b);
 [A when Integer?(A)]
-forceinline wrapSubtract(a:A, b:A) : A = numericSubtract(a, b);
+forceinline overload wrapSubtract(a:A, b:A) : A = numericSubtract(a, b);
 [A when Integer?(A)]
-forceinline wrapMultiply(a:A, b:A) : A = numericMultiply(a, b);
+forceinline overload wrapMultiply(a:A, b:A) : A = numericMultiply(a, b);
 [A when Integer?(A)]
-forceinline wrapQuotient(a:A, b:A) : A =  integerQuotient(a, b);
+forceinline overload wrapQuotient(a:A, b:A) : A =  integerQuotient(a, b);
 [A when Integer?(A)]
-forceinline wrapRemainder(a:A, b:A) : A = integerRemainder(a, b);
+forceinline overload wrapRemainder(a:A, b:A) : A = integerRemainder(a, b);
 
 [A, ..AA when equalValues?(A,..AA) and countValues(..AA) != 1]
 forceinline overload wrapAdd(a:A, ..aa:AA) : A = foldValues(wrapAdd, a, ..aa);

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -66,7 +66,10 @@ LValueCoordinate?(T) =
     LValue?(dereference(typeToLValue(T)));
 
 // true if adjacent coordinates point to adjacent locations in memory
-ContiguousCoordinate?(T) : Bool = false;
+[T]
+define ContiguousCoordinate?(#T) : Bool;
+
+overload ContiguousCoordinate?(T) : Bool = false;
 
 
 
@@ -200,19 +203,29 @@ SequenceCoordinateType(T) = Type(begin(typeToLValue(T)));
 SequenceIteratorType(T) = Type(iterator(typeToLValue(T)));
 
 // true if sequence elements are stored contiguously in memory
-ContiguousSequence?(T) : Bool = false;
+[T]
+define ContiguousSequence?(#T) : Bool;
+
+overload ContiguousSequence?(T) : Bool = false;
 
 // true if copying the sequence is efficient
-LightweightSequence?(T) : Bool = false;
+[T]
+define LightweightSequence?(#T) : Bool;
+
+overload LightweightSequence?(T) : Bool = false;
 
 // true for sequences which have value semantics.
-SequenceContainer?(T) : Bool = false;
+[T]
+define SequenceContainer?(#T) : Bool;
+
+overload SequenceContainer?(T) : Bool = false;
 
 // true if sequence is not single-valued (0 valued sequences are included).
 MultiValuedSequence?(T) : Bool =
     Sequence?(T) and multiValued?(..Type(..getValue(nextValue(iterator(typeToLValue(T))))));
 
-private multiValued?(..x) : Bool = true;
+private define multiValued?(..x) : Bool;
+overload multiValued?(..x) : Bool = true;
 overload multiValued?(x) : Bool = false;
 
 
@@ -244,7 +257,9 @@ alias RValue?(x) : Bool = not LValue?(x);
 
 /// @section  defaults 
 
-forceinline initialize(a) : {
+define initialize;
+
+forceinline overload initialize(a) : {
     a <-- Type(a)();
 }
 
@@ -274,7 +289,8 @@ forceinline overload prefixUpdateAssign(#F, ref dest, forward ..src) : {
 
 forceinline overload (!=)(a, b) : Bool = not (==)(a, b);
 
-forceinline ordered?(a, b) : Bool = (<=)(a, b) or (<=)(b, a);
+define ordered?;
+forceinline overload ordered?(a, b) : Bool = (<=)(a, b) or (<=)(b, a);
 
 forceinline overload (<=)(a, b) : Bool = not (<)(b, a);
 
@@ -487,13 +503,18 @@ overload operatorAssociativity(#(>)) : Int    = BOOLEAN;
 overload operatorAssociativity(#(<=)) : Int   = BOOLEAN;
 overload operatorAssociativity(#(>=)) : Int   = BOOLEAN;
 
-forceinline Operator?(..x) : Bool = false;
+define Operator?(..x) : Bool;
+forceinline overload Operator?(..x) : Bool = false;
 [OP] forceinline overload Operator?(#OP) : Bool 
     = Symbol?(OP) and operatorPrecedence(OP) > 0;
 
-forceinline BoolAssoc?(..x) : Bool = false;
-forceinline LeftAssoc?(..x) : Bool = false;
-forceinline RightAssoc?(..x) : Bool = false;
+define BoolAssoc?(..x) : Bool;
+define LeftAssoc?(..x) : Bool;
+define RightAssoc?(..x) : Bool;
+
+forceinline overload BoolAssoc?(..x) : Bool = false;
+forceinline overload LeftAssoc?(..x) : Bool = false;
+forceinline overload RightAssoc?(..x) : Bool = false;
 
 [OP] forceinline overload BoolAssoc?(#OP) : Bool = integerEquals?(operatorAssociativity(OP),BOOLEAN);
 [OP1,OP2] forceinline overload BoolAssoc?(#OP1,#OP2) : Bool = BoolAssoc?(OP1) and BoolAssoc?(OP2);
@@ -566,7 +587,9 @@ forceinline overload infixOperator(forward a, #OP, forward b)
 
 /// @section  swap 
 
-forceinline swap(a, b) : {
+define swap(a, b) :;
+
+forceinline overload swap(a, b) : {
     var temp = moveUnsafe(a);
     a <-- moveUnsafe(b);
     b <-- move(temp);
@@ -583,8 +606,11 @@ forceinline overload swap(a:T, b:T) : {
 
 /// @section  min, max 
 
+define min;
+define max;
+
 [T]
-forceinline min(a:T, b:T) --> c:T {
+forceinline overload min(a:T, b:T) --> c:T {
     if (a <= b)
         c <-- a;
     else
@@ -600,7 +626,7 @@ forceinline overload min(ref a:T, ref b:T)  : ByRef[T]  {
 }
 
 [T]
-forceinline max(a:T, b:T) --> c:T {
+forceinline overload max(a:T, b:T) --> c:T {
     if (a > b)
         c <-- a;
     else
@@ -669,7 +695,9 @@ bitror(x:I, n:J) = (|)((>>)(x, n), wrapBitshl(x, TypeSize(I)*8 - n));
 
 /// @section  PrimitiveType? 
 
-PrimitiveType?(X) = false;
+[T]
+define PrimitiveType?(#T) : Bool;
+overload PrimitiveType?(X) = false;
 overload PrimitiveType?(#Bool) : Bool = true;
 overload PrimitiveType?(#Int8) : Bool = true;
 overload PrimitiveType?(#Int16) : Bool = true;
@@ -704,7 +732,9 @@ overload PrimitiveType?(#Tuple[]) : Bool = true;
 
 /// @section  PrimitiveCompoundType?, PrimitiveCompoundMemberTypes 
 
-PrimitiveCompoundType?(X) : Bool = false;
+[T]
+define PrimitiveCompoundType?(#T) : Bool;
+overload PrimitiveCompoundType?(X) : Bool = false;
 
 [T,n] overload PrimitiveCompoundType?(#Array[T,n]) : Bool = true;
 [..T] overload PrimitiveCompoundType?(#Tuple[..T]) : Bool = true;
@@ -722,7 +752,9 @@ overload PrimitiveCompoundMemberTypes(#V) = ..VariantMembers(V);
 
 /// @section  PODType? 
 
-PODType?(X) : Bool = false;
+[T]
+define PODType?(#T) : Bool;
+overload PODType?(X) : Bool = false;
 
 [T when PrimitiveType?(T)]
 overload PODType?(#T) : Bool = true;
@@ -734,14 +766,31 @@ overload PODType?(#T) : Bool = allValues?(PODType?, ..PrimitiveCompoundMemberTyp
 
 /// @section  Finer-grained POD-related properties 
 
-BitwiseCopiedType?(T) = PODType?(T);
-BitwiseMovedType?(T) = PODType?(T);
-NotDestroyedType?(T) = PODType?(T);
-NotResetType?(T) = PODType?(T);
-CopyDoesNotThrowType?(T) = PODType?(T);
-AssignDoesNotThrowType?(T) = PODType?(T);
-BitwiseAssignedType?(T) = BitwiseCopiedType?(T) and NotDestroyedType?(T);
-BitwiseMoveAssignedType?(T) = BitwiseMovedType?(T) and NotDestroyedType?(T);
+[T]
+define BitwiseCopiedType?(#T) : Bool;
+[T]
+define BitwiseMovedType?(#T) : Bool;
+[T]
+define NotDestroyedType?(#T) : Bool;
+[T]
+define NotResetType?(#T) : Bool;
+[T]
+define CopyDoesNotThrowType?(#T) : Bool;
+[T]
+define AssignDoesNotThrowType?(#T) : Bool;
+[T]
+define BitwiseAssignedType?(#T) : Bool;
+[T]
+define BitwiseMoveAssignedType?(#T) : Bool;
+
+overload BitwiseCopiedType?(T) = PODType?(T);
+overload BitwiseMovedType?(T) = PODType?(T);
+overload NotDestroyedType?(T) = PODType?(T);
+overload NotResetType?(T) = PODType?(T);
+overload CopyDoesNotThrowType?(T) = PODType?(T);
+overload AssignDoesNotThrowType?(T) = PODType?(T);
+overload BitwiseAssignedType?(T) = BitwiseCopiedType?(T) and NotDestroyedType?(T);
+overload BitwiseMoveAssignedType?(T) = BitwiseMovedType?(T) and NotDestroyedType?(T);
 
 [T when PrimitiveCompoundType?(T)]
 overload BitwiseCopiedType?(#T) : Bool
@@ -772,7 +821,10 @@ overload BitwiseMoveAssignedType?(#T) : Bool
 
 /// @section  identity test 
 
-forceinline is?(x, y) : Bool = @x == @y;
+define is?;
+
+forceinline overload is?(x, y) : Bool = @x == @y;
+
 forceinline isNot?(x, y) : Bool = not is?(x, y);
 
 

--- a/lib-clay/core/operators/pod/pod.clay
+++ b/lib-clay/core/operators/pod/pod.clay
@@ -65,7 +65,9 @@ forceinline overload destroyMemory(begin:Pointer[P], end:Pointer[P]) : { }
 
 /// @section  value semantics for POD 
 
-[P] forceinline copyPOD(x: P) --> returned: P { memcpy(@returned, @x, TypeSize(P)); }
+define copyPOD;
+
+[P] forceinline overload copyPOD(x: P) --> returned: P { memcpy(@returned, @x, TypeSize(P)); }
 forceinline overload copyPOD(x: Bool) --> returned: Bool { bitcopy(returned, x); }
 [N when Numeric?(N)]
 forceinline overload copyPOD(x: N) --> returned: N { bitcopy(returned, x); }

--- a/lib-clay/core/pointers/pointers.clay
+++ b/lib-clay/core/pointers/pointers.clay
@@ -100,10 +100,12 @@ forceinline overload index(p:Pointer[T], i:I) = ref (p + i)^;
 
 /// @section  CodePointer?, ExternalCodePointer? 
 
-CodePointer?(x) = false;
+define CodePointer?(x) : Bool;
+overload CodePointer?(x) = false;
 [In,Out] overload CodePointer?(#CodePointer[In,Out]) = true;
 
-ExternalCodePointer?(x) = false;
+define ExternalCodePointer?(x) : Bool;
+overload ExternalCodePointer?(x) = false;
 [CC,V?,In,Out] overload ExternalCodePointer?(#ExternalCodePointer[CC,V?,In,Out]) = true;
 
 
@@ -204,8 +206,10 @@ forceinline overload null?(p:ExternalCodePointer[C,V,I,O]) {
 
 /// @section  ExternalCodePointer - call 
 
-[F, T]
-private CCastable?(#F, #T) = false;
+private define CCastable?;
+
+[F, T when Type?(F) and Type?(T)]
+overload CCastable?(#F, #T) = false;
 
 [F, T when Integer?(F) and Integer?(T) and TypeSize(T) >= TypeSize(F)]
 overload CCastable?(#F, #T) = true;
@@ -216,8 +220,11 @@ overload CCastable?(#Pointer[F], #Pointer[T]) = true;
 [F]
 overload CCastable?(#Pointer[F], #RawPointer) = true;
 
+[From, To]
+private define cCast(from:From, #To) : To;
+
 [F, T when CCastable?(F, T)]
-private cCast(from:F, #T) = T(from);
+overload cCast(from:F, #T) = T(from);
 
 [S when Sequence?(S) and (Char == SequenceElementType(S))]
 overload cCast(s:S, #Pointer[CChar]) = cstring(s);

--- a/lib-clay/core/records/records.clay
+++ b/lib-clay/core/records/records.clay
@@ -41,7 +41,10 @@ RecordFieldNames(R) = ..mapValues(
 //
 
 [T]
-RegularRecord?(#T) = false;
+define RegularRecord?(#T): Bool;
+
+[T]
+overload RegularRecord?(#T) = false;
 
 [T when Record?(T)]
 overload RegularRecord?(#T) = true;
@@ -50,8 +53,11 @@ overload RegularRecord?(#T) = true;
 
 /// @section  basic constructor 
 
+[T, ..A when Record?(T)]
+define initializeRecord(#T, ..args:A): T;
+
 [T, ..A when Record?(T) and (Tuple[..RecordFieldTypes(T)] == Tuple[..A])]
-alias initializeRecord(#T, ..args:A) --> returned:T {
+alias overload initializeRecord(#T, ..args:A) --> returned:T {
     ..recordFields(returned) <-- ..args;
 }
 

--- a/lib-clay/core/statics/statics.clay
+++ b/lib-clay/core/statics/statics.clay
@@ -5,7 +5,8 @@ public import __primitives__.(Static);
 
 /// @section  Static? predicate 
 
-Static?(x) : Bool = false;
+define Static?(x) : Bool;
+overload Static?(x) : Bool = false;
 [T] overload Static?(#T) : Bool = true;
 
 

--- a/lib-clay/core/strings/stringliterals/stringliterals.clay
+++ b/lib-clay/core/strings/stringliterals/stringliterals.clay
@@ -56,7 +56,9 @@ forceinline overload staticIndex(#s, #n) {
 
 /// @section  cstring 
 
-forceinline cstring(a:StringLiteralRef) = Pointer[Int8](begin(a));
+define cstring(a) : Pointer[Int8];
+
+forceinline overload cstring(a:StringLiteralRef) = Pointer[Int8](begin(a));
 
 [s when StringLiteral?(s)]
 forceinline overload cstring(#s) = Pointer[Int8](begin(s));
@@ -77,7 +79,8 @@ forceinline overload reverseIterator(#s) =
 
 /// @section  string literal concatenation 
 
-private StringLiteralStatic?(S) = false;
+private define StringLiteralStatic?(s) : Bool;
+overload StringLiteralStatic?(s) = false;
 [s]
 overload StringLiteralStatic?(#Static[s]) = StringLiteral?(s);
 
@@ -91,7 +94,10 @@ forceinline overload (++)(..ss:SS) = stringLiteralConcat(..ss);
 
 // stringLiteralStartsWith?
 
-stringLiteralStartsWith?(identifier, startsWith) = false;
+define stringLiteralStartsWith?;
+
+overload stringLiteralStartsWith?(a, b) = false;
+
 [identifier, startsWith when size(identifier) >= size(startsWith)]
 overload stringLiteralStartsWith?(#identifier, #startsWith)
       = stringLiteralByteSlice(identifier, #0, #size(startsWith))
@@ -99,7 +105,10 @@ overload stringLiteralStartsWith?(#identifier, #startsWith)
 
 // stringLiteralEndsWith?
 
-stringLiteralEndsWith?(identifier, endsWith) = false;
+define stringLiteralEndsWith?;
+
+overload stringLiteralEndsWith?(a, b) = false;
+
 [identifier, endsWith when size(identifier) >= size(endsWith)]
 overload stringLiteralEndsWith?(#identifier, #endsWith)
     = stringLiteralByteSlice(identifier,
@@ -109,10 +118,12 @@ overload stringLiteralEndsWith?(#identifier, #endsWith)
 
 // stringLiteralFind
 
+define stringLiteralFind;
+
 [identifier, sub, start when
     StringLiteral?(identifier) and StringLiteral?(sub)
 ]
-stringLiteralFind(#identifier, #sub, #start)
+overload stringLiteralFind(#identifier, #sub, #start)
     = stringLiteralFind(identifier, sub, #(start + 1));
 
 [identifier, sub, start when
@@ -146,12 +157,15 @@ overload strl() = "";
 
 // stringLiteralCapitalize, stringLiteralDecapitalize
 
-stringLiteralCapitalize("") = "";
+define stringLiteralCapitalize;
+define stringLiteralDecapitalize;
+
+overload stringLiteralCapitalize("") = "";
 [s when StringLiteral?(s) and size(s) >= 1]
 overload stringLiteralCapitalize(#s)
     = stringLiteralConcat(stringLiteralFromBytes(#(Int(asciiUpper(s.0)))), stringLiteralByteSlice(s, #1, #size(s)));
 
-stringLiteralDecapitalize("") = "";
+overload stringLiteralDecapitalize("") = "";
 [s when StringLiteral?(s) and size(s) >= 1]
 overload stringLiteralDecapitalize(#s)
     = stringLiteralConcat(stringLiteralFromBytes(#(Int(asciiLower(s.0)))), stringLiteralByteSlice(s, #1, #size(s)));

--- a/lib-clay/core/strings/strings.clay
+++ b/lib-clay/core/strings/strings.clay
@@ -6,8 +6,11 @@
 
 /// @section  String? 
 
+[T]
+define String?(#T) : Bool;
+
 [A]
-String?(#A) = false;
+overload String?(#A) = false;
 
 [A when Sequence?(A) and (Char == SequenceElementType(A))]
 overload String?(#A) = true;
@@ -17,7 +20,10 @@ overload String?(#A) = true;
 /// @section  SizedString? 
 
 [A]
-SizedString?(#A) = false;
+define SizedString?(#A) : Bool;
+
+[A]
+overload SizedString?(#A) = false;
 
 [A when SizedSequence?(A) and (Char == SequenceElementType(A))]
 overload SizedString?(#A) = true;
@@ -27,7 +33,10 @@ overload SizedString?(#A) = true;
 /// @section  ContiguousString? 
 
 [A]
-ContiguousString?(#A) = false;
+define ContiguousString?(#A) : Bool;
+
+[A]
+overload ContiguousString?(#A) = false;
 
 [A when ContiguousSequence?(A) and (Char == SequenceElementType(A))]
 overload ContiguousString?(#A) = true;
@@ -37,9 +46,5 @@ overload ContiguousString?(#A) = true;
 /// @section  CCompatibleString? 
 
 [A]
-CCompatibleString?(#A) = false;
-
-[A when String?(A) and CallDefined?(cstring, A)]
-overload CCompatibleString?(#A) = true;
-
+CCompatibleString?(#A) = String?(A) and CallDefined?(cstring, A);
 

--- a/lib-clay/core/tuples/tuples.clay
+++ b/lib-clay/core/tuples/tuples.clay
@@ -3,7 +3,9 @@ import __operators__;
 
 /// @section  Tuple? 
 
-Tuple?(x) = false;
+[T]
+define Tuple?(#T) : Bool;
+overload Tuple?(x) = false;
 [..T] overload Tuple?(#Tuple[..T]) : Bool = true;
 
 
@@ -33,7 +35,9 @@ forceinline unpackTupleRef(x:Tuple[..T]) = ref ..tupleElements(x);
 
 /// @section  unpack, unpackRef 
 
-forceinline unpackRef(x) = ref x;
+define unpackRef;
+
+forceinline overload unpackRef(x) = ref x;
 [..T]
 forceinline overload unpackRef(x:Tuple[..T]) = ref ..unpackTupleRef(x);
 

--- a/lib-clay/core/unions/unions.clay
+++ b/lib-clay/core/unions/unions.clay
@@ -2,7 +2,10 @@
 
 /// @section  Union? 
 
-Union?(x) = false;
+[T]
+define Union?(#T) : Bool;
+
+overload Union?(x) = false;
 [..T] overload Union?(#Union[..T]) : Bool = true;
 
 

--- a/lib-clay/core/values/values.clay
+++ b/lib-clay/core/values/values.clay
@@ -76,8 +76,11 @@ forceinline lastValue(..a, forward last) = forward last;
 
 /// @section  replicateValue, allValues?, anyValues?, equalValues?, inValues? 
 
+[n when n >= 0]
+define replicateValue(a, #n);
+
 [n when n > 0]
-forceinline replicateValue(a, #n) = a, ..replicateValue(a, #(n-1));
+forceinline overload replicateValue(a, #n) = a, ..replicateValue(a, #(n-1));
 [n when n == 0]
 forceinline overload replicateValue(a, #n) = ;
 
@@ -115,7 +118,9 @@ private record CapturedRValue[T] (
     value: T
 );
 
-CapturedValue?(a) = false;
+define CapturedValue?(a) : Bool;
+
+overload CapturedValue?(a) = false;
 [T]
 overload CapturedValue?(#CapturedLValue[T]) = true;
 [T]
@@ -153,10 +158,12 @@ forceinline capturedRefs(x:Tuple[..T]) =
 [S, n when Sequence?(S)]
 sequenceValues(seq: S, #n) = forward ..iteratorValues(iterator(seq), #n);
 
-[I when Iterator?(I)]
-iteratorValues(iter: I, #0) = ;
-[I, n when Iterator?(I) and n > 0]
-overload iteratorValues(iter: I, #n) {
+[I, n when Iterator?(I)]
+define iteratorValues(iter:I, #n);
+
+overload iteratorValues(iter, #0) = ;
+[n when n > 0]
+overload iteratorValues(iter, #n) {
     var v = nextValue(iter);
     assert["boundsChecks"](hasValue?(v));
     return forward ..getValue(v), ..iteratorValues(iter, #(n-1));
@@ -165,13 +172,18 @@ overload iteratorValues(iter: I, #n) {
 
 
 /// @section  iterate over two sets of values in tandem 
-[n when n > 0] eachValue2(fn, #n, forward x, forward ..xs) {
+define eachValue2;
+
+[n when n > 0]
+overload eachValue2(fn, #n, forward x, forward ..xs) {
     fn(x, nthValue(#(n-1), ..xs));
     return ..eachValue2(fn, #(n-1), ..withoutNthValue(#(n-1), ..xs));
 }
 overload eachValue2(fn, #0, forward ..xs) { }
 
-[n when n > 0] mapValues2(fn, #n, forward x, forward ..xs)
+define mapValues2;
+[n when n > 0]
+overload mapValues2(fn, #n, forward x, forward ..xs)
     = forward fn(x, nthValue(#(n-1), ..xs)),
       ..mapValues2(fn, #(n-1), ..withoutNthValue(#(n-1), ..xs));
 overload mapValues2(fn, #0, forward ..xs) = ;
@@ -180,22 +192,28 @@ overload mapValues2(fn, #0, forward ..xs) = ;
 
 /// @section  treat multiple #tuple values as key-values pairs 
 
+define assocValue;
+
 [key]
-assocValue(#key, kv, forward ..kvs) = forward ..assocValue(#key, ..kvs);
+overload assocValue(#key, kv, forward ..kvs) = forward ..assocValue(#key, ..kvs);
 
 [key, ..T]
 overload assocValue(#key, forward kv: Tuple[Static[key], ..T], ..kvs)
     = forward ..restValues(..unpack(kv));
 
+
 [key]
-assocValue?(#key) = false;
+define assocValue?(#key, ..kvs) : Bool;
+[key]
+overload assocValue?(#key) = false;
 [key]
 overload assocValue?(#key, kv, ..kvs) = assocValue?(key, ..kvs);
 [key, ..T]
 overload assocValue?(#key, kv: Tuple[Static[key], ..T], ..kvs) = true;
 
+define assocCountValues;
 [key]
-assocCountValues(#key) = -1;
+overload assocCountValues(#key) = -1;
 [key]
 overload assocCountValues(#key, kv, ..kvs) = assocCountValues(key, ..kvs);
 [key, ..T]
@@ -205,8 +223,9 @@ overload assocCountValues(#key, kv: Tuple[Static[key], ..T], ..kvs) = countValue
 
 /// @section  find the index of a value within a value list 
 
+private define _valueIndex;
 [n, value, other]
-private _valueIndex(#n, #value, #other, ..etc)
+overload _valueIndex(#n, #value, #other, ..etc)
     = _valueIndex(#(n+1), #value, ..etc);
 [n, value]
 overload _valueIndex(#n, #value, #value, ..etc) = n;

--- a/lib-clay/core/variants/nested/nested.clay
+++ b/lib-clay/core/variants/nested/nested.clay
@@ -13,8 +13,11 @@ private SubVariants(V) =
 VariantNestingPaths(#V, #M) =
     ..VariantNestingPaths2(V, M, []);
 
+
+private define VariantNestingPaths2;
+
 [V,M]
-private VariantNestingPaths2(#V, #M, Prefix) {
+overload VariantNestingPaths2(#V, #M, Prefix) {
     alias SubV = Tuple(..SubVariants(V));
     return ..VariantNestingPaths3(SubV, M, Prefix, #0);
 }
@@ -26,8 +29,10 @@ overload VariantNestingPaths2(#V, #M, Prefix) {
            ..VariantNestingPaths3(SubV, M, Prefix, #0);
 }
 
+private define VariantNestingPaths3;
+
 [i]
-private VariantNestingPaths3(Vs, M, Prefix, #i) {
+overload VariantNestingPaths3(Vs, M, Prefix, #i) {
     alias V = staticIndex(Vs, #i);
     alias NewPrefix = Tuple(..unpack(Prefix), V);
     return ..VariantNestingPaths2(V, M, NewPrefix),
@@ -52,7 +57,10 @@ forceinline nestedVariantIs?(x:V, #T) {
 /// @section  nestedVariantAs 
 
 [V, T when Variant?(V)]
-forceinline nestedVariantAs(ref x:V, #T) {
+define nestedVariantAs(x:V, #T);
+
+[V, T when Variant?(V)]
+forceinline overload nestedVariantAs(ref x:V, #T) {
     var ptr = nestedVariantAsPtr(x, T);
     assert(not null?(ptr));
     return ref ptr^;
@@ -74,7 +82,9 @@ nestedVariantAsPtr(x:V, #Target) {
     return unboxAlongPaths(x, Target, ..VariantNestingPaths(V, Target));
 }
 
-private forceinline unboxAlongPaths(x, Target, firstPath, ..rest) {
+private define unboxAlongPaths;
+
+forceinline overload unboxAlongPaths(x, Target, firstPath, ..rest) {
     var ptr = unboxAlong(x, Target, ..unpack(firstPath));
     if (not null?(ptr))
         return ptr;
@@ -83,7 +93,9 @@ private forceinline unboxAlongPaths(x, Target, firstPath, ..rest) {
 
 forceinline overload unboxAlongPaths(x, Target) = null(Target);
 
-private forceinline unboxAlong(x, Target, first, ..rest) {
+private define unboxAlong;
+
+forceinline overload unboxAlong(x, Target, first, ..rest) {
     var ptr = variantAsPtr(x, first);
     if (null?(ptr))
         return null(Target);

--- a/lib-clay/crypto/digest/internal/internal.clay
+++ b/lib-clay/crypto/digest/internal/internal.clay
@@ -6,12 +6,16 @@ import byteorder.*;
 
 
 // true iff A is digest algorithm name
+
 [A]
-Algorithm?(#A) = #false;
+define Algorithm?(#A): Bool;
+overload Algorithm?(A) = false;
 
 // true iff T is digest output
+
 [T]
-Digest?(#T) = false;
+define Digest?(#T): Bool;
+overload Digest?(T) = false;
 
 // algorithm name by digest or by digest context
 [T when Digest?(T) or DigestContext?(T)]
@@ -22,8 +26,10 @@ define Algorithm(#T);
 define DigestSize(#A): UInt;
 
 // true iff T is digest compute context
+
 [T]
-DigestContext?(#T) = false;
+define DigestContext?(#T): Bool;
+overload DigestContext?(T) = false;
 
 // Hash function input block size. This function is a part of public API
 // because some algorithms (like HMAC) need to know it

--- a/lib-clay/deques/deques.clay
+++ b/lib-clay/deques/deques.clay
@@ -428,7 +428,9 @@ overload remove(deque: Deque[T], i: DequeCoordinate[T]) {
 private alias DEQUE_TARGET_BUFFER_SIZE = SizeT(512);
 private alias DEQUE_INITIAL_MAP_SIZE = SizeT(8);
 
-DequeBufferSize(T) {
+define DequeBufferSize;
+
+overload DequeBufferSize(T) {
     if (TypeSize(T) < DEQUE_TARGET_BUFFER_SIZE)
         return DEQUE_TARGET_BUFFER_SIZE \ TypeSize(T);
     else
@@ -650,8 +652,10 @@ private printMap(deque) {
     }
 }
 
+private define insertDequeSequence;
+
 [T, S when Sequence?(S)]
-private insertDequeSequence(deque: Deque[T], i: DequeCoordinate[T], forward seq: S) {
+overload insertDequeSequence(deque: Deque[T], i: DequeCoordinate[T], forward seq: S) {
     for (x in reversed(seq))
         insertDequeValue(deque, i, seq);
 }

--- a/lib-clay/hash/hash.clay
+++ b/lib-clay/hash/hash.clay
@@ -61,7 +61,9 @@ forceinline overload hash(a:Array[T,n]) = hashSequence(a);
 
 /// @section  tuples 
 
-forceinline hashValues(..values) {
+define hashValues;
+
+forceinline overload hashValues(..values) {
     var h = SizeT(0);
     ..for (x in values)
         h = wrapAdd(wrapMultiply(SizeT(7), h), wrapMultiply(SizeT(13), hash(x)));

--- a/lib-clay/interfaces/interfaces.clay
+++ b/lib-clay/interfaces/interfaces.clay
@@ -9,7 +9,9 @@ private VtblSlotFunction(memFun) = memFun.0;
 private VtblSlotInputTypes(memFun) = ..unpack(memFun.1);
 private VtblSlotOutputTypes(memFun) = ..unpack(memFun.2);
 
-InterfaceMember?(I, fn) = false;
+define InterfaceMember?;
+
+overload InterfaceMember?(I, fn) = false;
 
 [I, fn when InterfaceType?(I)]
 overload InterfaceMember?(#I, #fn)

--- a/lib-clay/io/sockets/sockets.clay
+++ b/lib-clay/io/sockets/sockets.clay
@@ -149,7 +149,10 @@ overload lookupInetHostname(hostname: S) {
 
 
 /// @section  socket objects 
-Socket?(X) = false;
+
+define Socket?;
+
+overload Socket?(X) = false;
 
 record ListenSocket[Addr] (raw: platform.RawSocket);
 record StreamSocket (raw: platform.RawSocket);

--- a/lib-clay/keywordarguments/keywordarguments.clay
+++ b/lib-clay/keywordarguments/keywordarguments.clay
@@ -6,8 +6,10 @@ keywordArguments(names, forward ..keywords)
         ..unpack(names)
     );
 
+define getKeywordArgument;
+
 [I when StringLiteral?(I)]
-getKeywordArgument(#I, forward ..keywords)
+overload getKeywordArgument(#I, forward ..keywords)
     = forward assocValue(I, ..keywords);
 
 [I, T when StringLiteral?(I)]

--- a/lib-clay/math/libm/libm.clay
+++ b/lib-clay/math/libm/libm.clay
@@ -2,7 +2,8 @@ import libc;
 public import complex.*;
 public import numbers.floats.*;
 
-forceinline pow(x:Double,y:Double) = libc.pow(x,y);
+define pow;
+forceinline overload pow(x:Double,y:Double) = libc.pow(x,y);
 forceinline overload pow(x:Float,y:Float) = libc.powf(x,y);
 forceinline overload pow(x:LongDouble,y:LongDouble) = libc.powl(x,y);
 forceinline overload pow(x:Double,y:Float) = libc.pow(x,Double(y));
@@ -16,33 +17,40 @@ forceinline overload pow(x:LongDouble,y:Float) = libc.powl(x,LongDouble(y));
 [T when Integer?(T)] forceinline overload pow(x:Float,y:T) = libc.powf(x,Float(y));
 [T when Integer?(T)] forceinline overload pow(x:LongDouble,y:T) = libc.powl(x,LongDouble(y));
 
-forceinline abs(x:Double) = libc.fabs(x);
+define abs;
+forceinline overload abs(x:Double) = libc.fabs(x);
 forceinline overload abs(x:Float) = libc.fabsf(x);
 forceinline overload abs(x:LongDouble) = libc.fabsl(x);
 forceinline overload abs(x:Int) = libc.abs(x);
 forceinline overload abs(x:Long) = libc.llabs(x);
 
-forceinline exp(x:Double) = libc.exp(x);
+define exp;
+forceinline overload exp(x:Double) = libc.exp(x);
 forceinline overload exp(x:Float) = libc.expf(x);
 forceinline overload exp(x:LongDouble) = libc.expl(x);
 
-forceinline log(x:Double) = libc.log(x);
+define log;
+forceinline overload log(x:Double) = libc.log(x);
 forceinline overload log(x:Float) = libc.logf(x);
 forceinline overload log(x:LongDouble) = libc.logl(x);
 
-forceinline acos(x:Double) = libc.acos(x);
+define acos;
+forceinline overload acos(x:Double) = libc.acos(x);
 forceinline overload acos(x:Float) = libc.acosf(x);
 forceinline overload acos(x:LongDouble) = libc.acosl(x);
 
-forceinline asin(x:Double) = libc.asin(x);
+define asin;
+forceinline overload asin(x:Double) = libc.asin(x);
 forceinline overload asin(x:Float) = libc.asinf(x);
 forceinline overload asin(x:LongDouble) = libc.asinl(x);
 
-forceinline atan(x:Double) = libc.atan(x);
+define atan;
+forceinline overload atan(x:Double) = libc.atan(x);
 forceinline overload atan(x:Float) = libc.atanf(x);
 forceinline overload atan(x:LongDouble) = libc.atanl(x);
 
-forceinline atan2(x:Double,y:Double) = libc.atan2(x,y);
+define atan2;
+forceinline overload atan2(x:Double,y:Double) = libc.atan2(x,y);
 forceinline overload atan2(x:Float,y:Float) = libc.atan2f(x,y);
 forceinline overload atan2(x:LongDouble,y:LongDouble) = libc.atan2l(x,y);
 forceinline overload atan2(x:Double,y:Float) = libc.atan2(x,Double(y));
@@ -52,59 +60,73 @@ forceinline overload atan2(x:LongDouble,y:Double) = libc.atan2l(x,LongDouble(y))
 forceinline overload atan2(x:Float,y:LongDouble) = libc.atan2l(LongDouble(x),y);
 forceinline overload atan2(x:LongDouble,y:Float) = libc.atan2l(x,LongDouble(y));
 
-forceinline cos(x:Double) = libc.cos(x);
+define cos;
+forceinline overload cos(x:Double) = libc.cos(x);
 forceinline overload cos(x:Float) = libc.cosf(x);
 forceinline overload cos(x:LongDouble) = libc.cosl(x);
 
-forceinline sin(x:Double) = libc.sin(x);
+define sin;
+forceinline overload sin(x:Double) = libc.sin(x);
 forceinline overload sin(x:Float) = libc.sinf(x);
 forceinline overload sin(x:LongDouble) = libc.sinl(x);
 
-forceinline tan(x:Double) = libc.tan(x);
+define tan;
+forceinline overload tan(x:Double) = libc.tan(x);
 forceinline overload tan(x:Float) = libc.tanf(x);
 forceinline overload tan(x:LongDouble) = libc.tanl(x);
 
-forceinline cosh(x:Double) = libc.cosh(x);
+define cosh;
+forceinline overload cosh(x:Double) = libc.cosh(x);
 forceinline overload cosh(x:Float) = libc.coshf(x);
 forceinline overload cosh(x:LongDouble) = libc.coshl(x);
 
-forceinline sinh(x:Double) = libc.sinh(x);
+define sinh;
+forceinline overload sinh(x:Double) = libc.sinh(x);
 forceinline overload sinh(x:Float) = libc.sinhf(x);
 forceinline overload sinh(x:LongDouble) = libc.sinhl(x);
 
-forceinline tanh(x:Double) = libc.tanh(x);
+define tanh;
+forceinline overload tanh(x:Double) = libc.tanh(x);
 forceinline overload tanh(x:Float) = libc.tanhf(x);
 forceinline overload tanh(x:LongDouble) = libc.tanhl(x);
 
-forceinline acosh(x:Double) = libc.acosh(x);
+define acosh;
+forceinline overload acosh(x:Double) = libc.acosh(x);
 forceinline overload acosh(x:Float) = libc.acoshf(x);
 forceinline overload acosh(x:LongDouble) = libc.acoshl(x);
 
-forceinline asinh(x:Double) = libc.asinh(x);
+define asinh;
+forceinline overload asinh(x:Double) = libc.asinh(x);
 forceinline overload asinh(x:Float) = libc.asinhf(x);
 forceinline overload asinh(x:LongDouble) = libc.asinhl(x);
 
-forceinline atanh(x:Double) = libc.atanh(x);
+define atanh;
+forceinline overload atanh(x:Double) = libc.atanh(x);
 forceinline overload atanh(x:Float) = libc.atanhf(x);
 forceinline overload atanh(x:LongDouble) = libc.atanhl(x);
 
-forceinline log10(x:Double) = libc.log10(x);
+define log10;
+forceinline overload log10(x:Double) = libc.log10(x);
 forceinline overload log10(x:Float) = libc.log10f(x);
 forceinline overload log10(x:LongDouble) = libc.log10l(x);
 
-forceinline frexp(x:Double, ex:Pointer[Int]) = libc.frexp(x,ex);
+define frexp;
+forceinline overload frexp(x:Double, ex:Pointer[Int]) = libc.frexp(x,ex);
 forceinline overload frexp(x:Float, ex:Pointer[Int]) = libc.frexpf(x,ex);
 forceinline overload frexp(x:LongDouble, ex:Pointer[Int]) = libc.frexpl(x,ex);
 
-forceinline ldexp(x:Double,y:Int) = libc.ldexp(x,y);
+define ldexp;
+forceinline overload ldexp(x:Double,y:Int) = libc.ldexp(x,y);
 forceinline overload ldexp(x:Float,y:Int) = libc.ldexpf(x,y);
 forceinline overload ldexp(x:LongDouble,y:Int) = libc.ldexpl(x,y);
 
-forceinline modf(x:Double,iptr:Pointer[Int]) = libc.modf(x,iptr);
+define modf;
+forceinline overload modf(x:Double,iptr:Pointer[Int]) = libc.modf(x,iptr);
 forceinline overload modf(x:Float,iptr:Pointer[Int]) = libc.modff(x,iptr);
 forceinline overload modf(x:LongDouble,iptr:Pointer[Int]) = libc.modfl(x,iptr);
 
-forceinline hypot(x:Double,y:Double) = libc.hypot(x,y);
+define hypot;
+forceinline overload hypot(x:Double,y:Double) = libc.hypot(x,y);
 forceinline overload hypot(x:Float,y:Float) = libc.hypotf(x,y);
 forceinline overload hypot(x:LongDouble,y:LongDouble) = libc.hypotl(x,y);
 forceinline overload hypot(x:Double,y:Float) = libc.hypot(x,Double(y));
@@ -114,47 +136,58 @@ forceinline overload hypot(x:LongDouble,y:Double) = libc.hypotl(x,LongDouble(y))
 forceinline overload hypot(x:Float,y:LongDouble) = libc.hypotl(LongDouble(x),y);
 forceinline overload hypot(x:LongDouble,y:Float) = libc.hypotl(x,LongDouble(y));
 
-forceinline expm1(x:Double) = libc.expm1(x);
+define expm1;
+forceinline overload expm1(x:Double) = libc.expm1(x);
 forceinline overload expm1(x:Float) = libc.expm1f(x);
 forceinline overload expm1(x:LongDouble) = libc.expm1l(x);
 
-forceinline log1p(x:Double) = libc.log1p(x);
+define log1p;
+forceinline overload log1p(x:Double) = libc.log1p(x);
 forceinline overload log1p(x:Float) = libc.log1pf(x);
 forceinline overload log1p(x:LongDouble) = libc.log1pl(x);
 
-forceinline logb(x:Double) = libc.logb(x);
+define logb;
+forceinline overload logb(x:Double) = libc.logb(x);
 forceinline overload logb(x:Float) = libc.logbf(x);
 forceinline overload logb(x:LongDouble) = libc.logbl(x);
 
-forceinline exp2(x:Double) = libc.exp2(x);
+define exp2;
+forceinline overload exp2(x:Double) = libc.exp2(x);
 forceinline overload exp2(x:Float) = libc.exp2f(x);
 forceinline overload exp2(x:LongDouble) = libc.exp2l(x);
 
-forceinline log2(x:Double) = libc.log2(x);
+define log2;
+forceinline overload log2(x:Double) = libc.log2(x);
 forceinline overload log2(x:Float) = libc.log2f(x);
 forceinline overload log2(x:LongDouble) = libc.log2l(x);
 
-forceinline sqrt(x:Double) = libc.sqrt(x);
+define sqrt;
+forceinline overload sqrt(x:Double) = libc.sqrt(x);
 forceinline overload sqrt(x:Float) = libc.sqrtf(x);
 forceinline overload sqrt(x:LongDouble) = libc.sqrtl(x);
 
-forceinline cbrt(x:Double) = libc.cbrt(x);
+define cbrt;
+forceinline overload cbrt(x:Double) = libc.cbrt(x);
 forceinline overload cbrt(x:Float) = libc.cbrtf(x);
 forceinline overload cbrt(x:LongDouble) = libc.cbrtl(x);
 
-forceinline floor(x:Double) = libc.floor(x);
+define floor;
+forceinline overload floor(x:Double) = libc.floor(x);
 forceinline overload floor(x:Float) = libc.floorf(x);
 forceinline overload floor(x:LongDouble) = libc.floorl(x);
 
-forceinline ceil(x:Double) = libc.ceil(x);
+define ceil;
+forceinline overload ceil(x:Double) = libc.ceil(x);
 forceinline overload ceil(x:Float) = libc.ceilf(x);
 forceinline overload ceil(x:LongDouble) = libc.ceill(x);
 
-forceinline round(x:Double) = libc.round(x);
+define round;
+forceinline overload round(x:Double) = libc.round(x);
 forceinline overload round(x:Float) = libc.roundf(x);
 forceinline overload round(x:LongDouble) = libc.roundl(x);
 
-forceinline fmod(x:Double,y:Double) = libc.fmod(x,y);
+define fmod;
+forceinline overload fmod(x:Double,y:Double) = libc.fmod(x,y);
 forceinline overload fmod(x:Float,y:Float) = libc.fmodf(x,y);
 forceinline overload fmod(x:LongDouble,y:LongDouble) = libc.fmodl(x,y);
 forceinline overload fmod(x:Double,y:Float) = libc.fmod(x,Double(y));
@@ -175,11 +208,13 @@ forceinline infinity?(x:T) = if(_isinf(x)==1) true else false;
 [T when Float?(T)] 
 forceinline negativeInfinity?(x:T) = if(_isinf(x)==-1) true else false;
 
-forceinline finite?(x:Double) = Bool(libc.finite(x));
+define finite?;
+forceinline overload finite?(x:Double) = Bool(libc.finite(x));
 forceinline overload finite?(x:Float) = Bool(libc.finitef(x));
 forceinline overload finite?(x:LongDouble) = Bool(libc.finitel(x));
 
-forceinline drem(x:Double,y:Double) = libc.drem(x,y);
+define drem;
+forceinline overload drem(x:Double,y:Double) = libc.drem(x,y);
 forceinline overload drem(x:Float,y:Float) = libc.dremf(x,y);
 forceinline overload drem(x:LongDouble,y:LongDouble) = libc.dreml(x,y);
 forceinline overload drem(x:Double,y:Float) = libc.drem(x,Double(y));
@@ -189,35 +224,43 @@ forceinline overload drem(x:LongDouble,y:Double) = libc.dreml(x,LongDouble(y));
 forceinline overload drem(x:Float,y:LongDouble) = libc.dreml(LongDouble(x),y);
 forceinline overload drem(x:LongDouble,y:Float) = libc.dreml(x,LongDouble(y));
 
-forceinline nan?(x:Double) = Bool(libc.isnan(x));
+define nan?;
+forceinline overload nan?(x:Double) = Bool(libc.isnan(x));
 forceinline overload nan?(x:Float) = Bool(libc.isnanf(x));
 forceinline overload nan?(x:LongDouble) = Bool(libc.isnanl(x));
 
-forceinline jn(x:Int,y:Double) = libc.jn(x,y);
+define jn;
+forceinline overload jn(x:Int,y:Double) = libc.jn(x,y);
 forceinline overload jn(x:Int,y:Float) = libc.jnf(x,y);
 forceinline overload jn(x:Int,y:LongDouble) = libc.jnl(x,y);
 
-forceinline j0(x:Double) = libc.j0(x);
+define j0;
+forceinline overload j0(x:Double) = libc.j0(x);
 forceinline overload j0(x:Float) = libc.j0f(x);
 forceinline overload j0(x:LongDouble) = libc.j0l(x);
 
-forceinline j1(x:Double) = libc.j1(x);
+define j1;
+forceinline overload j1(x:Double) = libc.j1(x);
 forceinline overload j1(x:Float) = libc.j1f(x);
 forceinline overload j1(x:LongDouble) = libc.j1l(x);
 
-forceinline y0(x:Double) = libc.y0(x);
+define y0;
+forceinline overload y0(x:Double) = libc.y0(x);
 forceinline overload y0(x:Float) = libc.y0f(x);
 forceinline overload y0(x:LongDouble) = libc.y0l(x);
 
-forceinline y1(x:Double) = libc.y1(x);
+define y1;
+forceinline overload y1(x:Double) = libc.y1(x);
 forceinline overload y1(x:Float) = libc.y1f(x);
 forceinline overload y1(x:LongDouble) = libc.y1l(x);
 
-forceinline yn(x:Int,y:Double) = libc.yn(x,y);
+define yn;
+forceinline overload yn(x:Int,y:Double) = libc.yn(x,y);
 forceinline overload yn(x:Int,y:Float) = libc.ynf(x,y);
 forceinline overload yn(x:Int,y:LongDouble) = libc.ynl(x,y);
 
-forceinline copysign(x:Double,y:Double) = libc.copysign(x,y);
+define copysign;
+forceinline overload copysign(x:Double,y:Double) = libc.copysign(x,y);
 forceinline overload copysign(x:Float,y:Float) = libc.copysignf(x,y);
 forceinline overload copysign(x:LongDouble,y:LongDouble) = libc.copysignl(x,y);
 forceinline overload copysign(x:Double,y:Float) = libc.copysign(x,Double(y));
@@ -227,37 +270,45 @@ forceinline overload copysign(x:LongDouble,y:Double) = libc.copysignl(x,LongDoub
 forceinline overload copysign(x:Float,y:LongDouble) = libc.copysignl(LongDouble(x),y);
 forceinline overload copysign(x:LongDouble,y:Float) = libc.copysignl(x,LongDouble(y));
 
-forceinline erf(x:Double) = libc.erf(x);
+define erf;
+forceinline overload erf(x:Double) = libc.erf(x);
 forceinline overload erf(x:Float) = libc.erff(x);
 forceinline overload erf(x:LongDouble) = libc.erfl(x);
 
-forceinline erfc(x:Double) = libc.erfc(x);
+define erfc;
+forceinline overload erfc(x:Double) = libc.erfc(x);
 forceinline overload erfc(x:Float) = libc.erfcf(x);
 forceinline overload erfc(x:LongDouble) = libc.erfcl(x);
 
-forceinline lgamma(x:Double) = libc.lgamma(x);
+define lgamma;
+forceinline overload lgamma(x:Double) = libc.lgamma(x);
 forceinline overload lgamma(x:Float) = libc.lgammaf(x);
 forceinline overload lgamma(x:LongDouble) = libc.lgammal(x);
 
-forceinline tgamma(x:Double) = libc.tgamma(x);
+define tgamma;
+forceinline overload tgamma(x:Double) = libc.tgamma(x);
 forceinline overload tgamma(x:Float) = libc.tgammaf(x);
 forceinline overload tgamma(x:LongDouble) = libc.tgammal(x);
 
 alias gamma = tgamma;
 
-forceinline gamma_r(x:Double,signgamp:Pointer[Int]) = libc.gamma_r(x,signgamp);
+define gamma_r;
+forceinline overload gamma_r(x:Double,signgamp:Pointer[Int]) = libc.gamma_r(x,signgamp);
 forceinline overload gamma_r(x:Float,signgamp:Pointer[Int]) = libc.gammaf_r(x,signgamp);
 forceinline overload gamma_r(x:LongDouble,signgamp:Pointer[Int]) = libc.gammal_r(x,signgamp);
 
-forceinline lgamma_r(x:Double,signgamp:Pointer[Int]) = libc.lgamma_r(x,signgamp);
+define lgamma_r;
+forceinline overload lgamma_r(x:Double,signgamp:Pointer[Int]) = libc.lgamma_r(x,signgamp);
 forceinline overload lgamma_r(x:Float,signgamp:Pointer[Int]) = libc.lgammaf_r(x,signgamp);
 forceinline overload lgamma_r(x:LongDouble,signgamp:Pointer[Int]) = libc.lgammal_r(x,signgamp);
 
-forceinline rint(x:Double) = libc.rint(x);
+define rint;
+forceinline overload rint(x:Double) = libc.rint(x);
 forceinline overload rint(x:Float) = libc.rintf(x);
 forceinline overload rint(x:LongDouble) = libc.rintl(x);
 
-forceinline nextafter(x:Double,y:Double) = libc.nextafter(x,y);
+define nextafter;
+forceinline overload nextafter(x:Double,y:Double) = libc.nextafter(x,y);
 forceinline overload nextafter(x:Float,y:Float) = libc.nextafterf(x,y);
 forceinline overload nextafter(x:LongDouble,y:LongDouble) = libc.nextafterl(x,y);
 forceinline overload nextafter(x:Double,y:Float) = libc.nextafter(x,Double(y));
@@ -267,7 +318,8 @@ forceinline overload nextafter(x:LongDouble,y:Double) = libc.nextafterl(x,LongDo
 forceinline overload nextafter(x:Float,y:LongDouble) = libc.nextafterl(LongDouble(x),y);
 forceinline overload nextafter(x:LongDouble,y:Float) = libc.nextafterl(x,LongDouble(y));
 
-forceinline remainder(x:Double,y:Double) = libc.remainder(x,y);
+define remainder;
+forceinline overload remainder(x:Double,y:Double) = libc.remainder(x,y);
 forceinline overload remainder(x:Float,y:Float) = libc.remainderf(x,y);
 forceinline overload remainder(x:LongDouble,y:LongDouble) = libc.remainderl(x,y);
 forceinline overload remainder(x:Double,y:Float) = libc.remainder(x,Double(y));
@@ -277,27 +329,33 @@ forceinline overload remainder(x:LongDouble,y:Double) = libc.remainderl(x,LongDo
 forceinline overload remainder(x:Float,y:LongDouble) = libc.remainderl(LongDouble(x),y);
 forceinline overload remainder(x:LongDouble,y:Float) = libc.remainderl(x,LongDouble(y));
 
-forceinline scalbn(x:Double,y:Int) = libc.scalbn(x,y);
+define scalbn;
+forceinline overload scalbn(x:Double,y:Int) = libc.scalbn(x,y);
 forceinline overload scalbn(x:Float,y:Int) = libc.scalbnf(x,y);
 forceinline overload scalbn(x:LongDouble,y:Int) = libc.scalbnl(x,y);
 
-forceinline scalbln(x:Double,y:Long) = libc.scalbln(x,y);
+define scalbln;
+forceinline overload scalbln(x:Double,y:Long) = libc.scalbln(x,y);
 forceinline overload scalbln(x:Float,y:Long) = libc.scalblnf(x,y);
 forceinline overload scalbln(x:LongDouble,y:Long) = libc.scalblnl(x,y);
 
-forceinline ilogb(x:Double) = libc.ilogb(x);
+define ilogb;
+forceinline overload ilogb(x:Double) = libc.ilogb(x);
 forceinline overload ilogb(x:Float) = libc.ilogbf(x);
 forceinline overload ilogb(x:LongDouble) = libc.ilogbl(x);
 
-forceinline nearbyint(x:Double) = libc.nearbyint(x);
+define nearbyint;
+forceinline overload nearbyint(x:Double) = libc.nearbyint(x);
 forceinline overload nearbyint(x:Float) = libc.nearbyintf(x);
 forceinline overload nearbyint(x:LongDouble) = libc.nearbyintl(x);
 
-forceinline trunc(x:Double) = libc.trunc(x);
+define trunc;
+forceinline overload trunc(x:Double) = libc.trunc(x);
 forceinline overload trunc(x:Float) = libc.truncf(x);
 forceinline overload trunc(x:LongDouble) = libc.truncl(x);
 
-forceinline remquo(x:Double,y:Double) {
+define remquo;
+forceinline overload remquo(x:Double,y:Double) {
     var quo = Pointer[Int]();
     var res = libc.remquo(x,y,quo);
     return res,quo[0];
@@ -313,8 +371,8 @@ forceinline overload remquo(x:LongDouble,y:LongDouble) {
     return res,quo[0];
 }
 
-
-forceinline fdim(x:Double,y:Double) = libc.fdim(x,y);
+define fdim;
+forceinline overload fdim(x:Double,y:Double) = libc.fdim(x,y);
 forceinline overload fdim(x:Float,y:Float) = libc.fdimf(x,y);
 forceinline overload fdim(x:LongDouble,y:LongDouble) = libc.fdiml(x,y);
 forceinline overload fdim(x:Double,y:Float) = libc.fdim(x,Double(y));
@@ -324,23 +382,28 @@ forceinline overload fdim(x:LongDouble,y:Double) = libc.fdiml(x,LongDouble(y));
 forceinline overload fdim(x:Float,y:LongDouble) = libc.fdiml(LongDouble(x),y);
 forceinline overload fdim(x:LongDouble,y:Float) = libc.fdiml(x,LongDouble(y));
 
-forceinline fpclassify(value:Double) = libc.__fpclassify(value);
+define fpclassify;
+forceinline overload fpclassify(value:Double) = libc.__fpclassify(value);
 forceinline overload fpclassify(value:Float) = libc.__fpclassifyf(value);
 forceinline overload fpclassify(value:LongDouble) = libc.__fpclassifyl(value);
 
-forceinline llrint(x:Double) = libc.llrint(x);
+define llrint;
+forceinline overload llrint(x:Double) = libc.llrint(x);
 forceinline overload llrint(x:Float) = libc.llrintf(x);
 forceinline overload llrint(x:LongDouble) = libc.llrintl(x);
 
-forceinline llround(x:Double) = libc.llround(x);
+define llround;
+forceinline overload llround(x:Double) = libc.llround(x);
 forceinline overload llround(x:Float) = libc.llroundf(x);
 forceinline overload llround(x:LongDouble) = libc.llroundl(x);
 
-forceinline signbit(value:Double) = libc.signbit(value);
+define signbit;
+forceinline overload signbit(value:Double) = libc.signbit(value);
 forceinline overload signbit(value:Float) = libc.signbitf(value);
 forceinline overload signbit(value:LongDouble) = libc.signbitl(value);
 
-forceinline fma(x:Double,y:Double,z:Double) = libc.fma(x,y,z);
+define fma;
+forceinline overload fma(x:Double,y:Double,z:Double) = libc.fma(x,y,z);
 forceinline overload fma(x:Float,y:Float,z:Float) = libc.fmaf(x,y,z);
 forceinline overload fma(x:LongDouble,y:LongDouble,z:LongDouble) = libc.fmal(x,y,z);
 
@@ -348,7 +411,8 @@ forceinline overload abs(z:Complex64) = libc.cabs(z);
 forceinline overload abs(z:Complex32) = libc.cabsf(z);
 forceinline overload abs(z:Complex80) = libc.cabsl(z);
 
-forceinline arg(z:Complex64) = libc.carg(z);
+define arg;
+forceinline overload arg(z:Complex64) = libc.carg(z);
 forceinline overload arg(z:Complex32) = libc.cargf(z);
 forceinline overload arg(z:Complex80) = libc.cargl(z);
 
@@ -423,7 +487,8 @@ forceinline overload sqrt(z:Complex64) = libc.csqrt(z);
 forceinline overload sqrt(z:Complex32) = libc.csqrtf(z);
 forceinline overload sqrt(z:Complex80) = libc.csqrtl(z);
 
-forceinline proj(z:Complex64) = libc.cproj(z);
+define proj;
+forceinline overload proj(z:Complex64) = libc.cproj(z);
 forceinline overload proj(z:Complex32) = libc.cprojf(z);
 forceinline overload proj(z:Complex80) = libc.cprojl(z);
 

--- a/lib-clay/math/native/gamma.clay
+++ b/lib-clay/math/native/gamma.clay
@@ -4,7 +4,9 @@ import math.native.kernel.ieee754.*;
 import math.native.protocol.*;
 import math.native.constants.(M_PI);
 
-maxGamma(#Float) = 35.04f;
+define maxGamma;
+
+overload maxGamma(#Float) = 35.04f;
 overload maxGamma(#Double) = 171.6025;
 overload maxGamma(#LongDouble) = 1755.5323977l;
 
@@ -245,7 +247,9 @@ gamma_r (x:Double, signgamp:Pointer[Int]) {
 
 overload lgamma(x:Double) = lgamma_r(x,@signgam);
 
-tgamma(x:Double) = gamma_r(x,@signgam);
+define tgamma;
+
+overload tgamma(x:Double) = gamma_r(x,@signgam);
 
 
 overload lgamma(x:Float) = Float(lgamma(Double(x)));

--- a/lib-clay/math/native/ilogb.clay
+++ b/lib-clay/math/native/ilogb.clay
@@ -12,7 +12,9 @@ alias FP_ILOGBNAN = Least(Int32);
 
 alias logb = ilogb;
 
-ilogb(x:Float) = ilogb(Double(x));
+define ilogb;
+
+overload ilogb(x:Float) = ilogb(Double(x));
 
 overload ilogb(x:Double) {
 	

--- a/lib-clay/math/native/kernel/ieee754.clay
+++ b/lib-clay/math/native/kernel/ieee754.clay
@@ -6,37 +6,44 @@ alias db_zero = ieee_db(0.0);
 
 // Get two 32 bit ints from a double.  
 
-alias MAKE_IEEE(d:Double) = ieee_db(d);
+define MAKE_IEEE;
+alias overload MAKE_IEEE(d:Double) = ieee_db(d);
 alias overload MAKE_IEEE(l:Int64) = ieee_db(l);
 alias overload MAKE_IEEE(hi:Int32,lo:Int32) = ieee_db(array(lo,hi));
 alias overload MAKE_IEEE(lo:UInt32,hi:UInt32) 
     = MAKE_IEEE(bitcast(Int32,hi),bitcast(Int32,lo));
 
 // Get a 64-bit int from a double. 
-alias GET_IEEE_L(d:Double) = ieee_db(d).1;
+define GET_IEEE_L;
+alias overload GET_IEEE_L(d:Double) = ieee_db(d).1;
 alias overload GET_IEEE_L(x:ieee_db) = ref x.1; 
 alias overload GET_IEEE_L(hi,lo) = ieee_db(array(lo,hi)).1;
 
 // Get the more significant 32 bit int from a double.  
-alias GET_IEEE_HIGH(d:Double) = ieee_db(d).0[1];
+define GET_IEEE_HIGH;
+alias overload GET_IEEE_HIGH(d:Double) = ieee_db(d).0[1];
 alias overload GET_IEEE_HIGH(x:ieee_db) = ref x.0[1]; 
 alias overload GET_IEEE_HIGH(l:Int64) = ieee_db(l).0[1]; 
 
 // Get the less significant 32 bit int from a double.  
-alias GET_IEEE_LOW(d:Double) = ieee_db(d).0[0];
+define GET_IEEE_LOW;
+alias overload GET_IEEE_LOW(d:Double) = ieee_db(d).0[0];
 alias overload GET_IEEE_LOW(x:ieee_db) = ref x.0[0]; 
 alias overload GET_IEEE_LOW(l:Int64) = ieee_db(l).0[0]; 
 
-alias GET_IEEE_DB(l:Int64) = ieee_db(l).2;
+define GET_IEEE_DB;
+alias overload GET_IEEE_DB(l:Int64) = ieee_db(l).2;
 alias overload GET_IEEE_DB(hi,lo) = ieee_db(array(lo,hi)).2;
 alias overload GET_IEEE_DB(x:ieee_db) = ref x.2;
 
-alias SET_IEEE(x:ieee_db,v:Double) { x.2 = v; }
+define SET_IEEE;
+alias overload SET_IEEE(x:ieee_db,v:Double) { x.2 = v; }
 alias overload SET_IEEE(x:ieee_db,v:Int64) { x.1 = v; }
 alias overload SET_IEEE(x:ieee_db,hi:Int32,lo:Int32) {x.0[1],x.0[0] = hi,lo;}
 
 // Set the more significant 32 bits of a double from an int.  
-alias SET_IEEE_HIGH(x:ieee_db,v:Int32) { x.0[1] = v; }
+define SET_IEEE_HIGH;
+alias overload SET_IEEE_HIGH(x:ieee_db,v:Int32) { x.0[1] = v; }
 alias overload SET_IEEE_HIGH(d:Double,v:Int32) {
     var x = ieee_db(d);
     x.0[1] = v;
@@ -48,7 +55,8 @@ alias overload SET_IEEE_HIGH(l:Int64,v:Int32) {
     return move(x).1;
 }
 
-alias SET_IEEE_LOW(x:ieee_db,v:Int32) { x.0[0] = v; }
+define SET_IEEE_LOW;
+alias overload SET_IEEE_LOW(x:ieee_db,v:Int32) { x.0[0] = v; }
 alias overload SET_IEEE_LOW(d:Double,v:Int32) {
     var x = ieee_db(d);
     x.0[0] = v;

--- a/lib-clay/math/native/llround.clay
+++ b/lib-clay/math/native/llround.clay
@@ -2,7 +2,9 @@
 
 import math.native.kernel.ieee754.*;
 
-llround(x:Float) {
+define llround;
+
+overload llround(x:Float) {
     var result = 0l;
     var i = floatBits(x);
     var j0 = bitand(bitshr(i,23),0xffu) - 0x7fu;

--- a/lib-clay/math/native/log2.clay
+++ b/lib-clay/math/native/log2.clay
@@ -11,7 +11,9 @@ import math.native.kernel.ieee754.*;
 import numbers.floats.(negativeInfinity,nan);
 
 
-log2(x:Float) = Float(log2(Double(x)));
+define log2;
+
+overload log2(x:Float) = Float(log2(Double(x)));
 
 overload log2(x:Double) {
 	alias ZERO = 0.;

--- a/lib-clay/math/native/native.clay
+++ b/lib-clay/math/native/native.clay
@@ -55,9 +55,10 @@ public import complex.*;
 import math.native.constants.(M_PI);
 import numbers.floats.(floatFromBits,floatExponent,mantissaSize);
 
+define recip;
 
 [T when Integer?(T)]
-forceinline recip(x:T) = T(0);
+forceinline overload recip(x:T) = T(0);
 [T when Float?(T)]
 forceinline overload recip(x:T) = T(1) / x;
 
@@ -118,7 +119,8 @@ forceinline rsqrt(x:T) = recip(sqrt(x));
 [T when Float?(T)] 
 forceinline sigmoid (x:T) = T(1) / (T(1) + exp (-x));
 
-forceinline normcoeff(#LongDouble) = floatFromBits(UInt128(0x4035ul));
+define normcoeff;
+forceinline overload normcoeff(#LongDouble) = floatFromBits(UInt128(0x4035ul));
 forceinline overload normcoeff(#Double) = floatFromBits(0x435ul);
 forceinline overload normcoeff(#Float) = floatFromBits(0x4Cu);
 

--- a/lib-clay/math/native/nextafter.clay
+++ b/lib-clay/math/native/nextafter.clay
@@ -5,8 +5,9 @@ import math.native.kernel.ieee754.*;
 // return the next machine floating-point number of x in the
 // direction toward y.
 
+define nextafter;
 
-nextafter(x:Double, y:Double){
+overload nextafter(x:Double, y:Double){
     alias MIN_SUB = LeastPositive(Double);
     var xdb,ydb = MAKE_IEEE(x),MAKE_IEEE(y);
 

--- a/lib-clay/math/native/sqrt.x86.clay
+++ b/lib-clay/math/native/sqrt.x86.clay
@@ -16,7 +16,8 @@ forceinline overload sqrt(x:Double) = x86_sqrtsd(Vec[Double,2](x,0.))[0];
 forceinline overload sqrt(z:I) = sqrt(Complex(z));
 
 
-alias thresh(#LongDouble) = 0xd.413cccfe77997ffp+16379fl;
+define thresh;
+alias overload thresh(#LongDouble) = 0xd.413cccfe77997ffp+16379fl;
 alias overload thresh(#Float)  = 0x1.a82797f7a7599p+126f;
 alias overload thresh(#Double) = 0x1.a827999fcef32p+1022;
 

--- a/lib-clay/numbers/floats/floats.clay
+++ b/lib-clay/numbers/floats/floats.clay
@@ -1,23 +1,28 @@
 record Float80Bits (mantissa:UInt64,exponent:UInt32);
 
-floatBits(f:ILongDouble) = bitcast(Float80Bits, f);
+define floatBits;
+overload floatBits(f:ILongDouble) = bitcast(Float80Bits, f);
 overload floatBits(f:IDouble) = bitcast(UInt64, f);
 overload floatBits(f:IFloat) = bitcast(UInt32, f);
 overload floatBits(f:LongDouble) = bitcast(Float80Bits, f);
 overload floatBits(f:Double) = bitcast(UInt64, f);
 overload floatBits(f:Float) = bitcast(UInt32, f);
 
-floatFromBits(m:UInt64,e:UInt32) = bitcast(LongDouble, Float80Bits(m,e));
+define floatFromBits;
+overload floatFromBits(m:UInt64,e:UInt32) = bitcast(LongDouble, Float80Bits(m,e));
 overload floatFromBits(b:UInt64) = bitcast(Double, b);
 overload floatFromBits(b:UInt32) = bitcast(Float, b);
 
-imagFromBits(m:UInt64,e:UInt64) = bitcast(ILongDouble, Float80Bits(m,e));
+define imagFromBits;
+overload imagFromBits(m:UInt64,e:UInt64) = bitcast(ILongDouble, Float80Bits(m,e));
 overload imagFromBits(b:UInt64) = bitcast(IDouble, b);
 overload imagFromBits(b:UInt32) = bitcast(IFloat, b);
 
 
+define floatFromParts;
+
 [I when Integer?(I)]
-floatFromParts(#LongDouble, neg?:Bool, exp:I, mant:UInt64)
+overload floatFromParts(#LongDouble, neg?:Bool, exp:I, mant:UInt64)
     = floatFromBits(mant, bitor( UInt64(exp),
         if (neg?) 0x0000_0000_0000_8000_ul else 0_ul));
 
@@ -52,19 +57,22 @@ overload floatFromParts(#IFloat ,neg?:Bool, exp:I, mant:UInt32)
         bitshl(bitand(UInt32(exp), exponentMask(IFloat)), mantissaSize(IFloat)),
         if (neg?) 0x8000_0000u else 0u ));
 
-floatNegative?(f:ILongDouble) = bitand(floatBits(f).exponent, 0x8000u) != 0;
+define floatNegative?;
+overload floatNegative?(f:ILongDouble) = bitand(floatBits(f).exponent, 0x8000u) != 0;
 overload floatNegative?(f:IDouble) = bitand(floatBits(f), 0x8000_0000_0000_0000_ul) != 0;
 overload floatNegative?(f:IFloat) = bitand(floatBits(f), 0x8000_0000u) != 0;
 overload floatNegative?(f:LongDouble) = bitand(floatBits(f).exponent, 0x8000u) != 0;
 overload floatNegative?(f:Double) = bitand(floatBits(f), 0x8000_0000_0000_0000_ul) != 0;
 overload floatNegative?(f:Float) = bitand(floatBits(f), 0x8000_0000u) != 0;
 
+define floatExponent;
 [T when Float?(T) or Imaginary?(T)]
-floatExponent(f:T) = bitand(bitshr(floatBits(f), mantissaSize(T)), exponentMask(T));
+overload floatExponent(f:T) = bitand(bitshr(floatBits(f), mantissaSize(T)), exponentMask(T));
 overload floatExponent(f:ILongDouble) = bitand(floatBits(f).exponent, 0x7FFFu);
 overload floatExponent(f:LongDouble) = bitand(floatBits(f).exponent, 0x7FFFu);
 
-floatMantissa(f:ILongDouble) = floatBits(f).mantissa;
+define floatMantissa;
+overload floatMantissa(f:ILongDouble) = floatBits(f).mantissa;
 overload floatMantissa(f:IDouble) = bitand(floatBits(f), mantissaMask(IDouble));
 overload floatMantissa(f:IFloat) = bitand(floatBits(f), mantissaMask(IFloat));
 overload floatMantissa(f:LongDouble) = floatBits(f).mantissa;
@@ -73,28 +81,32 @@ overload floatMantissa(f:Float) = bitand(floatBits(f), mantissaMask(Float));
 
 floatParts(f) = floatNegative?(f), floatExponent(f), floatMantissa(f);
 
-infinity(#ILongDouble) = imagFromBits(0x8000_0000_0000_0000_ul,0x0000_0000_0000_7FFF_ul);
+define infinity;
+overload infinity(#ILongDouble) = imagFromBits(0x8000_0000_0000_0000_ul,0x0000_0000_0000_7FFF_ul);
 overload infinity(#IDouble) = imagFromBits(0x7FF0_0000_0000_0000_ul);
 overload infinity(#IFloat) = imagFromBits(0x7F80_0000u);
 overload infinity(#LongDouble) = floatFromBits(0x8000_0000_0000_0000_ul,0x0000_0000_0000_7FFF_ul);
 overload infinity(#Double) = floatFromBits(0x7FF0_0000_0000_0000_ul);
 overload infinity(#Float) = floatFromBits(0x7F80_0000u);
 
-negativeInfinity(#ILongDouble) = imagFromBits(0x8000_0000_0000_0000_ul,0x0000_0000_0000_FFFF_ul);
+define negativeInfinity;
+overload negativeInfinity(#ILongDouble) = imagFromBits(0x8000_0000_0000_0000_ul,0x0000_0000_0000_FFFF_ul);
 overload negativeInfinity(#IDouble) = imagFromBits(0xFFF0_0000_0000_0000_ul);
 overload negativeInfinity(#IFloat) = imagFromBits(0xFF80_0000u);
 overload negativeInfinity(#LongDouble) = floatFromBits(0x8000_0000_0000_0000_ul,0x0000_0000_0000_FFFF_ul);
 overload negativeInfinity(#Double) = floatFromBits(0xFFF0_0000_0000_0000_ul);
 overload negativeInfinity(#Float) = floatFromBits(0xFF80_0000u);
 
-nan(#ILongDouble) = imagFromBits(0xC000_0000_0000_0000_ul,0x0000_0000_0000_7FFF_ul);
+define nan;
+overload nan(#ILongDouble) = imagFromBits(0xC000_0000_0000_0000_ul,0x0000_0000_0000_7FFF_ul);
 overload nan(#IDouble) = imagFromBits(0x7FF8_0000_0000_0000_ul);
 overload nan(#IFloat) = imagFromBits(0x7FC0_0000u);
 overload nan(#LongDouble) = floatFromBits(0xC000_0000_0000_0000_ul,0x0000_0000_0000_7FFF_ul);
 overload nan(#Double) = floatFromBits(0x7FF8_0000_0000_0000_ul);
 overload nan(#Float) = floatFromBits(0x7FC0_0000u);
 
-snan(#ILongDouble) = imagFromBits(0x8000_0000_0000_0001_ul,0x0000_0000_0000_7FFF_ul);
+define snan;
+overload snan(#ILongDouble) = imagFromBits(0x8000_0000_0000_0001_ul,0x0000_0000_0000_7FFF_ul);
 overload snan(#IDouble) = imagFromBits(0x7FF0_0000_0000_0001_ul);
 overload snan(#IFloat) = imagFromBits(0x7F80_0001u);
 overload snan(#LongDouble) = floatFromBits(0x8000_0000_0000_0001_ul,0x0000_0000_0000_7FFF_ul);
@@ -108,14 +120,16 @@ overload nan(#LongDouble, sign?:Bool, payload:UInt64) = floatFromParts(LongDoubl
 overload nan(#Double, sign?:Bool, payload:UInt64) = floatFromParts(Double,sign?, exponentMask(Double), payload);
 overload nan(#Float, sign?:Bool, payload:UInt32) = floatFromParts(Float,sign?, exponentMask(Float), payload);
 
-qnanMask(#ILongDouble) = wrapBitshl(0x1ul,mantissaSize(ILongDouble)-1);
+define qnanMask;
+overload qnanMask(#ILongDouble) = wrapBitshl(0x1ul,mantissaSize(ILongDouble)-1);
 overload qnanMask(#IDouble) = wrapBitshl(0x1ul,mantissaSize(IDouble)-1);
 overload qnanMask(#IFloat) = wrapBitshl(0x1u,mantissaSize(IFloat)-1);
 overload qnanMask(#LongDouble) = wrapBitshl(0x1ul,mantissaSize(LongDouble)-1);
 overload qnanMask(#Double) = wrapBitshl(0x1ul,mantissaSize(Double)-1);
 overload qnanMask(#Float) = wrapBitshl(0x1u,mantissaSize(Float)-1);
 
-snanMask(#ILongDouble) = bitshr(mantissaMask(ILongDouble),1);
+define snanMask;
+overload snanMask(#ILongDouble) = bitshr(mantissaMask(ILongDouble),1);
 overload snanMask(#IDouble) = bitshr(mantissaMask(IDouble),1);
 overload snanMask(#IFloat) = bitshr(mantissaMask(IFloat),1);
 overload snanMask(#LongDouble) = bitshr(mantissaMask(LongDouble),1);
@@ -128,63 +142,72 @@ overload nan(sign?:Bool, payload:T) = floatFromParts(T, sign?, exponentMask(T), 
 [T when Float?(T) or Imaginary?(T)]
 overload snan(sign?:Bool, payload:T) = floatFromParts(T, sign?, exponentMask(T), bitand(floatMantissa(payload),snanMask(T)));
 
-exponentBias(#ILongDouble) = 16383;
+define exponentBias;
+overload exponentBias(#ILongDouble) = 16383;
 overload exponentBias(#IDouble) = 1023;
 overload exponentBias(#IFloat) = 127;
 overload exponentBias(#LongDouble) = 16383;
 overload exponentBias(#Double) = 1023;
 overload exponentBias(#Float) = 127;
 
-mantissaSize(#ILongDouble) = 64;
+define mantissaSize;
+overload mantissaSize(#ILongDouble) = 64;
 overload mantissaSize(#IDouble) = 52;
 overload mantissaSize(#IFloat) = 23;
 overload mantissaSize(#LongDouble) = 64;
 overload mantissaSize(#Double) = 52;
 overload mantissaSize(#Float) = 23;
 
-mantissaMask(#ILongDouble) = 0xFFFF_FFFF_FFFF_FFFFul;
+define mantissaMask;
+overload mantissaMask(#ILongDouble) = 0xFFFF_FFFF_FFFF_FFFFul;
 overload mantissaMask(#IDouble) = 0x000F_FFFF_FFFF_FFFFul;
 overload mantissaMask(#IFloat) = 0x007F_FFFFu;
 overload mantissaMask(#LongDouble) = 0xFFFF_FFFF_FFFF_FFFFul;
 overload mantissaMask(#Double) = 0x000F_FFFF_FFFF_FFFFul;
 overload mantissaMask(#Float) = 0x007F_FFFFu;
 
-exponentSize(#ILongDouble) = 15;
+define exponentSize;
+overload exponentSize(#ILongDouble) = 15;
 overload exponentSize(#IDouble) = 11;
 overload exponentSize(#IFloat) = 8;
 overload exponentSize(#LongDouble) = 15;
 overload exponentSize(#Double) = 11;
 overload exponentSize(#Float) = 8;
 
-exponentMask(#ILongDouble) = 0x7FFFul;
+define exponentMask;
+overload exponentMask(#ILongDouble) = 0x7FFFul;
 overload exponentMask(#IDouble) = 0x7FFul;
 overload exponentMask(#IFloat) = 0xFFu;
 overload exponentMask(#LongDouble) = 0x7FFFul;
 overload exponentMask(#Double) = 0x7FFul;
 overload exponentMask(#Float) = 0xFFu;
 
-signMask(#ILongDouble) = 0x8000ul;
+define signMask;
+overload signMask(#ILongDouble) = 0x8000ul;
 overload signMask(#IDouble) = 0x8000_0000_0000_0000_ul;
 overload signMask(#IFloat) = 0x8000_0000_ul;
 overload signMask(#LongDouble) = 0x8000ul;
 overload signMask(#Double) = 0x8000_0000_0000_0000_ul;
 overload signMask(#Float) = 0x8000_0000_u;
 
-floatMantissaZero(#ILongDouble) = 0x8000_0000_0000_0000_ul;
+define floatMantissaZero;
+overload floatMantissaZero(#ILongDouble) = 0x8000_0000_0000_0000_ul;
 overload floatMantissaZero(#IDouble) = 0x0000_0000_0000_0000_ul;
 overload floatMantissaZero(#IFloat) = 0x0000_0000_u;
 overload floatMantissaZero(#LongDouble) = 0x8000_0000_0000_0000_ul;
 overload floatMantissaZero(#Double) = 0x0000_0000_0000_0000_ul;
 overload floatMantissaZero(#Float) = 0x0000_0000_u;
 
-signbit(x:ILongDouble) = Int(bitshr(floatBits(x).exponent,15));
+define signbit;
+overload signbit(x:ILongDouble) = Int(bitshr(floatBits(x).exponent,15));
 overload signbit(x:IDouble) = Int(bitshr(floatBits(x),63));
 overload signbit(x:IFloat) = Int(bitshr(floatBits(x),31));
 overload signbit(x:LongDouble) = Int(bitshr(floatBits(x).exponent,15));
 overload signbit(x:Double) = Int(bitshr(floatBits(x),63));
 overload signbit(x:Float) = Int(bitshr(floatBits(x),31));
 
-floatBitsUnsigned(x:ILongDouble) {
+define floatBitsUnsigned;
+overload floatBitsUnsigned(x:ILongDouble) {
     var tmp = floatBits(x);
     tmp.exponent = bitand(tmp.exponent,0x7FFFu);
     return tmp;
@@ -200,11 +223,19 @@ overload floatBitsUnsigned(x:Double) = bitand(floatBits(x),0x7FFF_FFFF_FFFF_FFFF
 overload floatBitsUnsigned(x:Float) = bitand(floatBits(x),0x7FFF_FFFFu);
 
 
-[T when Float?(T) or Imaginary?(T)] finite?(x:T) = floatExponent(x) != exponentMask(T);
-[T when Float?(T) or Imaginary?(T)] infinity?(x:T) = floatExponent(x) == exponentMask(T) and floatMantissa(x)==0;
-[T when Float?(T) or Imaginary?(T)] positiveInfinity?(x:T) = x == infinity(T);
-[T when Float?(T) or Imaginary?(T)] negativeInfinity?(x:T) = x == negativeInfinity(T);
-[T when Float?(T) or Imaginary?(T)] nan?(x:T) = floatExponent(x) == exponentMask(T) and floatMantissa(x)!=0;
+define finite?;
+define infinity?;
+define positiveInfinity?;
+define negativeInfinity?;
+define nan?;
+define subnormal?;
+define normalized?;
+
+[T when Float?(T) or Imaginary?(T)] overload finite?(x:T) = floatExponent(x) != exponentMask(T);
+[T when Float?(T) or Imaginary?(T)] overload infinity?(x:T) = floatExponent(x) == exponentMask(T) and floatMantissa(x)==0;
+[T when Float?(T) or Imaginary?(T)] overload positiveInfinity?(x:T) = x == infinity(T);
+[T when Float?(T) or Imaginary?(T)] overload negativeInfinity?(x:T) = x == negativeInfinity(T);
+[T when Float?(T) or Imaginary?(T)] overload nan?(x:T) = floatExponent(x) == exponentMask(T) and floatMantissa(x)!=0;
 [T when Float?(T) or Imaginary?(T)] qnan?(x:T) {
     var m = floatMantissa(x);
     return floatExponent(x) == exponentMask(T) and m!=0 and bitshr(m,mantissaSize(T)-1)==1;
@@ -213,6 +244,6 @@ overload floatBitsUnsigned(x:Float) = bitand(floatBits(x),0x7FFF_FFFFu);
     var m = floatMantissa(x);
     return floatExponent(x) == exponentMask(T) and m!=0 and bitshr(m,mantissaSize(T)-1)==0;
 }
-[T when Float?(T) or Imaginary?(T)] subnormal?(x:T) = floatExponent(x)==T(0) and x!=T(0);
-[T when Float?(T) or Imaginary?(T)] normalized?(x:T) = not subnormal?(x) and finite?(x);
+[T when Float?(T) or Imaginary?(T)] overload subnormal?(x:T) = floatExponent(x)==T(0) and x!=T(0);
+[T when Float?(T) or Imaginary?(T)] overload normalized?(x:T) = not subnormal?(x) and finite?(x);
 

--- a/lib-clay/numbers/parser/parser.clay
+++ b/lib-clay/numbers/parser/parser.clay
@@ -50,14 +50,18 @@ parseImagWith(s:S, imagType, convFunc) {
 
 /// @section  parseInt8, parseUInt8 
 
+define parseInt8;
+
 [S when String?(S)]
-parseInt8(s:S) = parseInt8(String(s));
+overload parseInt8(s:S) = parseInt8(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseInt8(s:S) = parseIntWith(s, Int8, libc.strtol);
 
+define parseUInt8;
+
 [S when String?(S)]
-parseUInt8(s:S) = parseUInt8(String(s));
+overload parseUInt8(s:S) = parseUInt8(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseUInt8(s:S) = parseIntWith(s, UInt8, libc.strtoul);
@@ -65,14 +69,18 @@ overload parseUInt8(s:S) = parseIntWith(s, UInt8, libc.strtoul);
 
 /// @section  parseInt16, parseUInt16 
 
+define parseInt16;
+
 [S when String?(S)]
-parseInt16(s:S) = parseInt16(String(s));
+overload parseInt16(s:S) = parseInt16(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseInt16(s:S) = parseIntWith(s, Int16, libc.strtol);
 
+define parseUInt16;
+
 [S when String?(S)]
-parseUInt16(s:S) = parseUInt16(String(s));
+overload parseUInt16(s:S) = parseUInt16(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseUInt16(s:S) =  parseIntWith(s, UInt16, libc.strtoul);
@@ -80,14 +88,18 @@ overload parseUInt16(s:S) =  parseIntWith(s, UInt16, libc.strtoul);
 
 /// @section  parseInt32, parseUInt32 
 
+define parseInt32;
+
 [S when String?(S)]
-parseInt32(s:S) = parseInt32(String(s));
+overload parseInt32(s:S) = parseInt32(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseInt32(s:S) = parseIntWith(s, Int32, libc.strtol);
 
+define parseUInt32;
+
 [S when String?(S)]
-parseUInt32(s:S) = parseUInt32(String(s));
+overload parseUInt32(s:S) = parseUInt32(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseUInt32(s:S) = parseIntWith(s, UInt32, libc.strtoul);
@@ -95,14 +107,18 @@ overload parseUInt32(s:S) = parseIntWith(s, UInt32, libc.strtoul);
 
 /// @section  parseInt64, parseUInt64 
 
+define parseInt64;
+
 [S when String?(S)]
-parseInt64(s:S) = parseInt64(String(s));
+overload parseInt64(s:S) = parseInt64(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseInt64(s:S) = parseIntWith(s, Int64, libc.strtoll);
 
+define parseUInt64;
+
 [S when String?(S)]
-parseUInt64(s:S) = parseUInt64(String(s));
+overload parseUInt64(s:S) = parseUInt64(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseUInt64(s:S) = parseIntWith(s, UInt64, libc.strtoull);
@@ -110,8 +126,10 @@ overload parseUInt64(s:S) = parseIntWith(s, UInt64, libc.strtoull);
 
 /// @section  parseFloat32 
 
+define parseFloat32;
+
 [S when String?(S)]
-parseFloat32(s:S) = parseFloat32(String(s));
+overload parseFloat32(s:S) = parseFloat32(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseFloat32(s:S) = parseFloatWith(s, Float32, libc.strtod);
@@ -119,16 +137,20 @@ overload parseFloat32(s:S) = parseFloatWith(s, Float32, libc.strtod);
 
 /// @section  parseFloat64 
 
+define parseFloat64;
+
 [S when String?(S)]
-parseFloat64(s:S) = parseFloat64(String(s));
+overload parseFloat64(s:S) = parseFloat64(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseFloat64(s:S) = parseFloatWith(s, Float64, libc.strtod);
 
 /// @section  parseFloat80 
 
+define parseFloat80;
+
 [S when String?(S)]
-parseFloat80(s:S) = parseFloat80(String(s));
+overload parseFloat80(s:S) = parseFloat80(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseFloat80(s:S) = parseFloatWith(s, Float80, libc.strtold);
@@ -136,8 +158,10 @@ overload parseFloat80(s:S) = parseFloatWith(s, Float80, libc.strtold);
 
 /// @section  parseImag32 
 
+define parseImag32;
+
 [S when String?(S)]
-parseImag32(s:S) = parseImag32(String(s));
+overload parseImag32(s:S) = parseImag32(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseImag32(s:S) = parseImagWith(s, Imag32, libc.strtod);
@@ -145,16 +169,20 @@ overload parseImag32(s:S) = parseImagWith(s, Imag32, libc.strtod);
 
 /// @section  parseImag64 
 
+define parseImag64;
+
 [S when String?(S)]
-parseImag64(s:S) = parseImag64(String(s));
+overload parseImag64(s:S) = parseImag64(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseImag64(s:S) = parseImagWith(s, Imag64, libc.strtod);
 
 /// @section  parseComplex80 
 
+define parseImag80;
+
 [S when String?(S)]
-parseImag80(s:S) = parseImag80(String(s));
+overload parseImag80(s:S) = parseImag80(String(s));
 
 [S when CCompatibleString?(S)]
 overload parseImag80(s:S) = parseImagWith(s, Imag80, libc.strtold);

--- a/lib-clay/parsing/combinators/generic/generic.clay
+++ b/lib-clay/parsing/combinators/generic/generic.clay
@@ -43,7 +43,8 @@ overload SimpleParser?(#TokenInput, #Parser) {
     return MaybeType?(..ReturnType(..parser(input)));
 }
 
-private MaybeType?(..args) = false;
+private define MaybeType?;
+overload MaybeType?(..args) = false;
 [T] overload MaybeType?(#Maybe[T]) = true;
 
 
@@ -167,8 +168,10 @@ literal(#TokenInput, expected:Token) =
 
 /// @section  literalString 
 
+define literalString;
+
 [TokenInput, A when Sequence?(A) and (SequenceElementType(A) == TokenType(TokenInput))]
-literalString(#TokenInput, forward a:A) {
+overload literalString(#TokenInput, forward a:A) {
     return input => {
         var saved = input;
         for (item in a) {

--- a/lib-clay/printer/formatter/formatter.clay
+++ b/lib-clay/printer/formatter/formatter.clay
@@ -5,7 +5,8 @@ import strings.*;
 
 /// @section  Formatter types 
 
-Formatter?(X) = false;
+define Formatter?;
+overload Formatter?(X) = false;
 
 formatter(F, forward x, forward ..params)
     = F[Type(captureValue(x))](captureValue(x), ..params);
@@ -59,7 +60,9 @@ HEX(forward x: I) = formatter(HEXFormatter, x);
 [I when Integer?(I)]
 oct(forward x: I) = formatter(OctFormatter, x);
 
-private _formatBase(stream, value, fmt) {
+private define _formatBase;
+
+overload _formatBase(stream, value, fmt) {
     if (value < 0) {
         printWithSprintf(stream, strl("-", fmt), wrapNegate(value));
     } else {
@@ -72,7 +75,9 @@ overload _formatBase(stream, value:U, fmt) {
     printWithSprintf(stream, fmt, value);
 }
 
-private formatBase(stream, value, fmt, fmt64) {
+private define formatBase;
+
+overload formatBase(stream, value, fmt, fmt64) {
     _formatBase(stream, value, fmt);
 }
 overload formatBase(stream, value: Int64, fmt, fmt64) {
@@ -219,13 +224,16 @@ private record RightAlignedFormatter[..C] (
     pad: Char,
 );
 
-private AlignedFormatter?(T) = false;
+private define AlignedFormatter?;
+overload AlignedFormatter?(T) = false;
 [..C] overload AlignedFormatter?(#LeftAlignedFormatter[..C]) = true;
 [..C] overload AlignedFormatter?(#RightAlignedFormatter[..C]) = true;
 [T when AlignedFormatter?(T)] overload Formatter?(#T) = true;
 
+private define alignedFormatter;
+
 [I when Integer?(I)]
-private alignedFormatter(F, width: I, pad: Char, forward ..values) {
+overload alignedFormatter(F, width: I, pad: Char, forward ..values) {
     // If printedWidth isn't available for all objects, print them to a string
     // and use the width of that
     var s = str(..values);

--- a/lib-clay/printer/observe/observe.clay
+++ b/lib-clay/printer/observe/observe.clay
@@ -5,7 +5,9 @@ import io.files.raw.(stderrRawFile);
 
 /// @section  observe, observeTo, observeCall -- log intermediate values and forward them 
 
-observeTo(stream, forward ..x) {
+define observeTo;
+
+overload observeTo(stream, forward ..x) {
     var captured = captureValues(..x);
     printlnTo(stream, "[observed: ", ..weaveValues(", ", ..capturedRefs(captured)), "]");
     flush(stream);

--- a/lib-clay/printer/types/types.clay
+++ b/lib-clay/printer/types/types.clay
@@ -421,7 +421,9 @@ overload printReprTo(stream, x:T) {
 
 /// @section  printReprValuesTo, printReprArgumentsTo, printReprElementsTo 
 
-printReprValuesTo(stream, value, ..values) {
+define printReprValuesTo;
+
+overload printReprValuesTo(stream, value, ..values) {
     printReprTo(stream, value);
     ..for (y in values) {
         printTo(stream, ", ");

--- a/lib-clay/referencetypes/referencetypes.clay
+++ b/lib-clay/referencetypes/referencetypes.clay
@@ -63,8 +63,10 @@ overload staticIndex(x:T, i);
 private fieldNameIndex(#T, #Field) =
     findField(#0, #Field, ..ReferenceTypeFieldNames(T));
 
+private define findField;
+
 [pos]
-private findField(#pos, field, first, ..rest) =
+overload findField(#pos, field, first, ..rest) =
     findField(#pos+1, field, ..rest);
 
 [pos, F]

--- a/lib-clay/remote/marshaling/marshaling.clay
+++ b/lib-clay/remote/marshaling/marshaling.clay
@@ -55,12 +55,16 @@ define marshalTo;
 define unmarshalFrom;
 // [T] UnmarshaledType(#T) T2
 // -- type that value of type T should be unmarshaled into
-UnmarshaledType(T) = T;
+define UnmarshaledType;
+
+overload UnmarshaledType(T) = T;
 
 record UnmarshalUnexpectedEOF ();
 instance Exception (UnmarshalUnexpectedEOF);
 
-Marshalable?(T)
+define Marshalable?;
+
+overload Marshalable?(T)
     =     CallDefined?(marshaledSize, MarshalContext, T)
       and CallDefined?(marshalTo, MarshalContext, Pointer[Byte], T)
       and CallDefined?(unmarshalFrom,
@@ -75,7 +79,9 @@ overload Marshalable?(#UnmarshalContext) = false;
 //
 // bitwise-marshalable implementation
 //
-BitwiseMarshalable?(T) = false;
+define BitwiseMarshalable?;
+
+overload BitwiseMarshalable?(T) = false;
 
 [T when BitwiseMarshalable?(T)]
 overload marshaledSize(context, x: T) = MarshalSize(TypeSize(T));
@@ -137,8 +143,10 @@ overload marshalTo(context, buffer_: Pointer[Byte], forward r: R) --> buffer: Po
     marshalMemberwise(context, buffer, ..recordFields(r));
 }
 
+define unmarshalMemberwise;
+
 [FieldT]
-unmarshalMemberwise(
+overload unmarshalMemberwise(
     context,
     begin: Pointer[Byte],
     end: Pointer[Byte],
@@ -217,8 +225,10 @@ overload marshalTo(context, buffer_: Pointer[Byte], v: V) --> buffer: Pointer[By
 record UnmarshalInvalidVariantTag (tag: Int);
 instance Exception (UnmarshalInvalidVariantTag);
 
+private define unmarshalVariantMember;
+
 [..T, n]
-private unmarshalVariantMember(
+overload unmarshalVariantMember(
     context,
     begin: Pointer[Byte],
     end: Pointer[Byte],
@@ -262,7 +272,9 @@ overload unmarshalFrom(context, begin_: Pointer[Byte], end: Pointer[Byte], #V)
 //
 // general sequence marshaling
 //
-private MarshalableSequence?(S)
+private define MarshalableSequence?;
+
+overload MarshalableSequence?(S)
     = SequenceContainer?(S) and Marshalable?(SequenceElementType(S));
 
 overload MarshalableSequence?(#StringLiteralRef) = true;
@@ -519,8 +531,12 @@ overload UnmarshaledType(#SharedPointer[T]) = SharedPointer[UnmarshaledType(T)];
 //
 // high-level interface
 //
-[T when T != MarshalContext] marshal(forward value:T, forward ..values)
+define marshal;
+
+[T when T != MarshalContext]
+overload marshal(forward value:T, forward ..values)
     = marshal(MarshalContext(), value, ..values);
+
 overload marshal() = Vector[Byte]();
 
 overload marshal(context: MarshalContext, forward ..values) --> returned: Vector[Byte] {
@@ -537,7 +553,9 @@ overload marshal(context: MarshalContext, forward ..values) --> returned: Vector
 
 overload marshal(context: MarshalContext) = Vector[Byte]();
 
-unmarshal(data: Vector[Byte], ..Types)
+define unmarshal;
+
+overload unmarshal(data: Vector[Byte], ..Types)
     = ..unmarshal(UnmarshalContext(), data, ..Types);
 overload unmarshal(context: UnmarshalContext, data: Vector[Byte], ..Types) {
     var b = begin(data);

--- a/lib-clay/remote/messages/messages.clay
+++ b/lib-clay/remote/messages/messages.clay
@@ -54,8 +54,10 @@ private var remoteCode[Protocol, ..Args] = createRemoteCode(Protocol, ..Args);
 
 
 /// @section  client interface 
+define remoteMessage;
+
 [Protocol, ..Args when CallDefined?(Protocol, ..Args)]
-remoteMessage(#Protocol, outstream, forward ..args: Args) {
+overload remoteMessage(#Protocol, outstream, forward ..args: Args) {
     var mArgs = marshal(..args);
     var mArgsSize = MarshalSize(size(mArgs));
     writeMarshalSize(outstream, remoteCode[Protocol, ..Args]);
@@ -87,8 +89,10 @@ private consume(stream, bytes_) {
     }
 }
 
+define answerRemoteMessage;
+
 [Protocol]
-answerRemoteMessage(#Protocol, instream, code: MarshalSize) {
+overload answerRemoteMessage(#Protocol, instream, code: MarshalSize) {
     if (code < size(remoteEntryPoints[Protocol])) {
         var mArgsSize = readMarshalSize(instream);
 
@@ -118,8 +122,10 @@ overload answerRemoteMessage(instream) {
     answerRemoteMessage(DefaultProtocol, instream);
 }
 
+define answerLoop;
+
 [Protocol]
-answerLoop(#Protocol, instream) {
+overload answerLoop(#Protocol, instream) {
     var code = maybeReadMarshalSize(instream);
     while(just?(code)) {
         answerRemoteMessage(instream, just(code));

--- a/lib-clay/sequences/lazy/filtered/filtered.clay
+++ b/lib-clay/sequences/lazy/filtered/filtered.clay
@@ -5,7 +5,9 @@ import sequences.lazy.zipped.*;
 
 /// @section  filtered 
 
-forceinline filtered(predicate, forward ..seqs) = Filtered(predicate, zipped(..seqs));
+define filtered(predicate, ..seqs);
+
+forceinline overload filtered(predicate, forward ..seqs) = Filtered(predicate, zipped(..seqs));
 
 forceinline overload filtered(predicate, forward seq) =
     Filtered(predicate, wrapSequence(seq));

--- a/lib-clay/sequences/lazy/mapped/mapped.clay
+++ b/lib-clay/sequences/lazy/mapped/mapped.clay
@@ -6,7 +6,9 @@ import sequences.force.*;
 
 /// @section  mapped 
 
-forceinline mapped(forward mapper, forward ..seqs) = Mapped(mapper, zipped(..seqs));
+define mapped(mapper, ..seqs);
+
+forceinline overload mapped(forward mapper, forward ..seqs) = Mapped(mapper, zipped(..seqs));
 
 forceinline overload mapped(forward mapper, forward seq) = Mapped(mapper, wrapSequence(seq));
 

--- a/lib-clay/sequences/sequences.clay
+++ b/lib-clay/sequences/sequences.clay
@@ -9,15 +9,25 @@ import vectors.*;
 // strict wrappers around lazy sequences
 //
 
-alias zip(..args) = force(zipped(..args));
-alias map(..args) = force(mapped(..args));
-alias filter(..args) = force(filtered(..args));
-alias enumerate(..args) = force(enumerated(..args));
-alias reverse(..args) = force(reversed(..args));
-alias slice(..args) = force(sliced(..args));
-alias sliceFrom(..args) = force(slicedFrom(..args));
-alias sliceUpto(..args) = force(slicedUpto(..args));
-alias group(..args) = force(grouped(..args));
+define zip;
+define map;
+define filter;
+define enumerate;
+define reverse;
+define slice;
+define sliceFrom;
+define sliceUpto;
+define group;
+
+alias overload zip(..args) = force(zipped(..args));
+alias overload map(..args) = force(mapped(..args));
+alias overload filter(..args) = force(filtered(..args));
+alias overload enumerate(..args) = force(enumerated(..args));
+alias overload reverse(..args) = force(reversed(..args));
+alias overload slice(..args) = force(sliced(..args));
+alias overload sliceFrom(..args) = force(slicedFrom(..args));
+alias overload sliceUpto(..args) = force(slicedUpto(..args));
+alias overload group(..args) = force(grouped(..args));
 
 
 

--- a/lib-clay/simd/simd.clay
+++ b/lib-clay/simd/simd.clay
@@ -213,7 +213,8 @@ forceinline overload bitnot(a:Vec[T,n]) = bitxor(Vec[T,n](componentMask(T)), a);
 
 /// @section  casting 
 
-CompatibleVectorTypes?(X, Y) = false;
+define CompatibleVectorTypes?(X, Y) : Bool;
+overload CompatibleVectorTypes?(X, Y) = false;
 [T,n, U,m when TypeSize(Vec[T,n]) == TypeSize(Vec[U,m])]
 overload CompatibleVectorTypes?(#Vec[T,n], #Vec[U,m]) = true;
 
@@ -224,7 +225,8 @@ forceinline overload Vec[T,n](v: Vec[U,m]) = bitcast(Vec[T,n], v);
 
 /// @section  boolean masks 
 
+define componentMask;
 [T when Integer?(T)]
-forceinline componentMask(#T) = wrapCast(T, -1);
+forceinline overload componentMask(#T) = wrapCast(T, -1);
 forceinline overload componentMask(#Float32) = bitcast(Float32, -1_i);
 forceinline overload componentMask(#Float64) = bitcast(Float64, -1_l);

--- a/lib-clay/test/test.clay
+++ b/lib-clay/test/test.clay
@@ -72,7 +72,9 @@ runTestSuite(suite: TestSuite) : TestStatus {
 pendingMessage(pending?: Bool) : String = 
     String(if (pending?) "(pending) " else "");
 
-printFailure(..xs) {
+define printFailure;
+
+overload printFailure(..xs) {
     printlnColored(Red, TEST_FAILURE_INDENT, ..xs);
 }
 [when Flag?("test.minimal")]
@@ -123,8 +125,10 @@ runTestCase(_case: TestCase) : TestStatus {
 passed(test: TestStatus) { test.passed +: 1; }
 failed(test: TestStatus) { test.failed +: 1; }
 
+define expect;
+
 // primitive assertion function
-expect(test: TestStatus, passed?: Bool, failReportFn) {
+overload expect(test: TestStatus, passed?: Bool, failReportFn) {
     if (passed?) {
         passed(test);
     } else {

--- a/lib-clay/twohash/implementation/implementation.clay
+++ b/lib-clay/twohash/implementation/implementation.clay
@@ -44,8 +44,10 @@ record TwoHash[E]
 [E]
 overload EntryType(#TwoHash[E]) = E;
 
+define TwoHash?;
+
 [T]
-TwoHash?(#T) = false;
+overload TwoHash?(#T) = false;
 
 [E]
 overload TwoHash?(#TwoHash[E]) = true;
@@ -209,11 +211,13 @@ retry:
 // freeEntry
 //
 
+define inside;
+
 [P]
 overload inside(v, p: P) = (SizeT(p) >= SizeT(@v) and SizeT(p) < SizeT(@v+1));
 
 [R, P when CallDefined?(begin, R)]
-inside(range: R, p: P) = (SizeT(p) >= SizeT(begin(range)) and SizeT(p) < SizeT(end(range)));
+overload inside(range: R, p: P) = (SizeT(p) >= SizeT(begin(range)) and SizeT(p) < SizeT(end(range)));
 
 [E]
 freeEntry(th: TwoHash[E], pEntry: Pointer[E])
@@ -340,7 +344,9 @@ largeHash(x)
     return wrapAdd(e, wrapBitshl(e, 32));
 }
 
-baseSplitHash(hash: UInt64)
+define baseSplitHash;
+
+overload baseSplitHash(hash: UInt64)
 {
     var lowHash = wrapCast(SizeT, bitand(hash, 127));
     var hash1 = wrapCast(SizeT, bitshr(hash, 8));
@@ -370,7 +376,9 @@ overload splitHash(th: TwoHash[E], entry: E) = baseSplitHash(th, entryHash(entry
 // helpers
 //
 
-moveEntry(entry, th) = move(entry);
+define moveEntry;
+
+overload moveEntry(entry, th) = move(entry);
 
 [E]
 allocateInBucket(th, b: Bucket[E], entry: E, hashByte)

--- a/lib-clay/twohash/twohash.clay
+++ b/lib-clay/twohash/twohash.clay
@@ -65,8 +65,10 @@ private record SetVectorEntry[K]
     prev: Pointer[SetVectorEntry[K]],
 );
 
+private define Entry?;
+
 [T]
-private Entry?(#T) = false;
+overload Entry?(#T) = false;
 
 [K]
 overload Entry?(#SetEntry[K]) = true;
@@ -77,8 +79,10 @@ overload Entry?(#MapEntry[K, V]) = true;
 [K]
 overload Entry?(#SetVectorEntry[K]) = true;
 
+private define HashSetLike?;
+
 [T, K]
-private HashSetLike?(#T, #K) = false;
+overload HashSetLike?(#T, #K) = false;
 
 [K]
 overload HashSetLike?(#HashSet[K], #K) = true;
@@ -90,8 +94,10 @@ overload HashSetLike?(#SetVector[K], #K) = true;
 // Type predicates
 //
 
+private define Hashtable?;
+
 [T]
-private Hashtable?(#T) = false;
+overload Hashtable?(#T) = false;
 
 [T when RecordWithField?(T, "data") and TwoHash?(Type(typeToLValue(T).data))]
 overload Hashtable?(#T) = true;

--- a/lib-clay/vectors/generic/generic.clay
+++ b/lib-clay/vectors/generic/generic.clay
@@ -132,8 +132,10 @@ private forceinline ensureSpace(a, space:SizeT) {
 
 /// @section insert
 
+private define insertLocationsUnsafe;
+
 [I, J when Integer?(I) and Integer?(J)]
-private insertLocationsUnsafe(a, pos:I, n:J) {
+overload insertLocationsUnsafe(a, pos:I, n:J) {
     return ..insertLocationsUnsafe(a, SizeT(pos), SizeT(n));
 }
 

--- a/lib-clay/vectors/vectors.clay
+++ b/lib-clay/vectors/vectors.clay
@@ -119,8 +119,10 @@ overload vectorRequestCapacity(a:Vector[T], capacity:SizeT) {
     reallocVector(a, n);
 }
 
+private define reallocVector;
+
 [T]
-private reallocVector(a:Vector[T], capacity:SizeT) {
+overload reallocVector(a:Vector[T], capacity:SizeT) {
     var data = allocateRawMemory(T, capacity);
     moveNonoverlappingMemoryUnsafe(data, a.data, a.data + a.size);
     freeRawMemory(a.data);

--- a/test/example/permissive/main.clay
+++ b/test/example/permissive/main.clay
@@ -29,7 +29,10 @@ overload permissiveAssign(dest:T, src:T) {
 // permissive record constructor
 //
 
-PermissiveRecordConstructor?(x) = false;
+[R]
+define PermissiveRecordConstructor?(#R) : Bool;
+
+overload PermissiveRecordConstructor?(x) = false;
 
 [T, ..A when Record?(T)
            and PermissiveRecordConstructor?(T)

--- a/test/lang/operators/custom/foo.clay
+++ b/test/lang/operators/custom/foo.clay
@@ -1,2 +1,5 @@
 import printer.(println);
-(~~)(a, b) { println("~~"); }
+
+define (~~);
+
+overload (~~)(a, b) { println("~~"); }

--- a/test/lang/overloads/standalone/compilererr.txt
+++ b/test/lang/overloads/standalone/compilererr.txt
@@ -1,0 +1,1 @@
+standalone functions cannot be overloaded

--- a/test/lang/overloads/standalone/main.clay
+++ b/test/lang/overloads/standalone/main.clay
@@ -1,0 +1,5 @@
+foo() {}
+
+overload foo(x) {}
+
+main() {}

--- a/test/lang/throwingbranches/main.clay
+++ b/test/lang/throwingbranches/main.clay
@@ -2,7 +2,8 @@ import printer.(println);
 record FooException ();
 instance Exception (FooException);
 
-foo(x: Int) : Int { throw FooException(); }
+define foo;
+overload foo(x: Int) : Int { throw FooException(); }
 overload foo(x: Float) : Int { return 5; }
 
 variant Foo (Int, Float);

--- a/test/lang/tuples/single/2/main.clay
+++ b/test/lang/tuples/single/2/main.clay
@@ -5,7 +5,9 @@ import printer.(println);
 
 record Thingy[XX] ();
 
-foo(x) { println("not a tuple"); }
+define foo;
+
+overload foo(x) { println("not a tuple"); }
 
 [..X] overload foo(#Thingy[[..X]]) { println(repr(..X)); }
 

--- a/test/lib-clay/byteorder/test.clay
+++ b/test/lib-clay/byteorder/test.clay
@@ -2,8 +2,10 @@ import byteorder.*;
 import printer.(str);
 import test.*;
 
+define testNetworkToHost;
+
 [IntType]
-testNetworkToHost(test: TestStatus, #IntType, function, expectReversed?) {
+overload testNetworkToHost(test: TestStatus, #IntType, function, expectReversed?) {
     alias S = #TypeSize(IntType);
     var digits = array(..mapValues(i -> UInt8(250 - i), ..integers(S)));
     var digitsReversed = array(..reverseValues(..arrayElements(digits)));

--- a/test/lib-clay/cocoa/objc/internals/test.macosx.clay
+++ b/test/lib-clay/cocoa/objc/internals/test.macosx.clay
@@ -175,7 +175,8 @@ __expectMsgSendCompatible(expectTF, test, ParamType, ValueType) {
     );
 }
 
-_expectMsgSendCompatible(expectTF, test, ParamType, ValueType) {
+define _expectMsgSendCompatible;
+overload _expectMsgSendCompatible(expectTF, test, ParamType, ValueType) {
     __expectMsgSendCompatible(expectTF, test, ParamType, ValueType);
 }
 [ParamType when ObjectType?(ParamType)]

--- a/test/lib-clay/io/sockets/addresses/test.clay
+++ b/test/lib-clay/io/sockets/addresses/test.clay
@@ -5,7 +5,9 @@ import byteorder.*;
 import vectors.*;
 import sequences.*;
 
-_expectSockaddrIn(test, name, expectedHost, expectedPort, sockaddr) {}
+define _expectSockaddrIn;
+
+overload _expectSockaddrIn(test, name, expectedHost, expectedPort, sockaddr) {}
 overload _expectSockaddrIn(test, name, expectedHost, expectedPort, sockaddr: Sockaddr_in)
 {
     expectEqual(test, "family of " ++ name, AF_INET, sockaddr.sin_family);

--- a/test/lib-clay/math/libm/test.clay
+++ b/test/lib-clay/math/libm/test.clay
@@ -17,7 +17,9 @@ var idata[T] = array(T(0),T(1),T(-1),T(3),T(38),Least(T)+T(1),Greatest(T));
 alias C1[T] = CodePointer[[T],[T]];
 alias C2[T] = CodePointer[[T,T],[T]];
 
-oneArgFuncs(T) = array(T(abs),T(sqrt),T(cbrt),T(trunc),T(round),
+define oneArgFuncs;
+
+overload oneArgFuncs(T) = array(T(abs),T(sqrt),T(cbrt),T(trunc),T(round),
                             T(ceil),T(floor),T(rint),T(sin),
                             T(cos),T(tan),T(asin),T(acos),T(atan),T(sinh),
                             T(cosh),T(tanh),T(exp),T(expm1),

--- a/test/lib-clay/printing/observe/main.clay
+++ b/test/lib-clay/printing/observe/main.clay
@@ -2,10 +2,12 @@ import printer.(println);
 import printer.observe.*;
 import strings.*;
 
-tellRvalue(ref x) = 0;
+define tellRvalue;
+overload tellRvalue(ref x) = 0;
 overload tellRvalue(rvalue x) = 1;
 
-tellRvalueString(ref x) = "ref";
+define tellRvalueString;
+overload tellRvalueString(ref x) = "ref";
 overload tellRvalueString(rvalue x) = "rvalue";
 
 record AnException ();


### PR DESCRIPTION
This code is compilation error now.

```
foo() = 1;
overload foo(x) = 2;
```

Fixes #406 (except for `private overload` part).
