### PR TITLE
algorithms min, max

### DIFF
--- a/lib-clay/algorithms/algorithms.clay
+++ b/lib-clay/algorithms/algorithms.clay
@@ -104,13 +104,13 @@ overload select(a:A, f) {
 
 
 
-/// @section  min, max for sequences 
+/// @section  selectMin, selectMax for sequences 
 
 [A when Sequence?(A)]
-overload min(a:A) = forward select(a, lesser?);
+selectMin(a:A) = forward select(a, lesser?);
 
 [A when Sequence?(A)]
-overload max(a:A) = forward select(a, greaterEquals?);
+selectMax(a:A) = forward select(a, greaterEquals?);
 
 
 

--- a/lib-clay/algorithms/algorithms.clay
+++ b/lib-clay/algorithms/algorithms.clay
@@ -110,7 +110,7 @@ overload select(a:A, f) {
 selectMin(a:A) = forward select(a, lesser?);
 
 [A when Sequence?(A)]
-selectMax(a:A) = forward select(a, greaterEquals?);
+selectMax(a:A) = forward select(a, greater?);
 
 
 

--- a/lib-clay/core/operators/operators.clay
+++ b/lib-clay/core/operators/operators.clay
@@ -606,8 +606,10 @@ forceinline overload swap(a:T, b:T) : {
 
 /// @section  min, max 
 
-define min;
-define max;
+[T]
+define min(a:T, b:T) : T;
+[T]
+define max(a:T, b:T) : T;
 
 [T]
 forceinline overload min(a:T, b:T) --> c:T {

--- a/test/lib-clay/sequences/4/main.clay
+++ b/test/lib-clay/sequences/4/main.clay
@@ -1,4 +1,4 @@
-import algorithms.(find,reduce,reduceBy,sum,product,binarySearch);
+import algorithms.(find,reduce,reduceBy,sum,product,binarySearch,selectMin,selectMax);
 import printer.(println,print,printTo);
 import sharedpointers.*;
 import sequences.*;
@@ -74,11 +74,11 @@ main() {
     }
 
     {
-        // test sum, product, min, max
+        // test sum, product, selectMin, selectMax
         var a = Vector(range(1, 11));
         println(sum(a));
         println(product(a));
-        swap(min(a), max(a));
+        swap(selectMin(a), selectMax(a));
         printList(a);
     }
 


### PR DESCRIPTION
- rename min, max -> selectMin, selectMax to avoid overloading with core.operators
- use `greater?` instead of `greaterEquals?` in selectMax to select first max element, like in `selectMin`
