### PR TITLE
algorithms.clay: add join with no separator (concat)

### DIFF
--- a/lib-clay/algorithms/algorithms.clay
+++ b/lib-clay/algorithms/algorithms.clay
@@ -296,6 +296,18 @@ overload advancePast(pos:C, x:T) {
 
 /// @section  join 
 
+define concat(seq);
+
+[A when Sequence?(A) and Sequence?(SequenceElementType(A))]
+overload concat(a:A) {
+    alias T = SequenceElementType(SequenceElementType(A));
+    var result = Vector[T]();
+    for (x in a) {
+        pushAll(result, x);
+    }
+    return move(result);
+}
+
 define join(sep, seq);
 
 [S, A when Sequence?(A) and Sequence?(SequenceElementType(A))

--- a/test/lib-clay/algorithms/main.clay
+++ b/test/lib-clay/algorithms/main.clay
@@ -1,4 +1,4 @@
-import algorithms.(find,endsWith?,beginsWith?,split,join);
+import algorithms.(find,endsWith?,beginsWith?,split,concat,join);
 import printer.(println);
 import strings.*;
 import sequences.*;
@@ -23,7 +23,8 @@ main() {
         println("find(", s, ", ", x, ") = ", find(s, x) - begin(s));
         println("split(", s, ", ", x, ") = ", split(s, x));
     }
-
+	
+    println(concat(a));
     println(join("", a));
     println(join(".", a));
     println(join('/', a));

--- a/test/lib-clay/algorithms/out.txt
+++ b/test/lib-clay/algorithms/out.txt
@@ -79,6 +79,7 @@ split(afoobarfoo, o) = {af, , barf, , }
 find(afoobarfoo, o) = 2
 split(afoobarfoo, o) = {af, , barf, , }
 foofoobarafoobarfoo
+foofoobarafoobarfoo
 .foo.foobar.afoobarfoo
 /foo/foobar/afoobarfoo
 {1, 2, 0, 2, 3, 0, 3, 4}


### PR DESCRIPTION
join("", seq) is good, but somethimes there's no way to create an empty sequence
