### PR TITLE
Basic check overload is compatible with define during loading

### DIFF
--- a/test/lang/overloads/declmismatch/param/1-2/compilererr.txt
+++ b/test/lang/overloads/declmismatch/param/1-2/compilererr.txt
@@ -1,0 +1,1 @@
+overload has more parameters \(2\) than declaration \(1\)

--- a/test/lang/overloads/declmismatch/param/1-2/main.clay
+++ b/test/lang/overloads/declmismatch/param/1-2/main.clay
@@ -1,0 +1,5 @@
+define foo(a);
+
+overload foo(a, b) = 1;
+
+main() {}

--- a/test/lang/overloads/declmismatch/param/1-2v/compilererr.txt
+++ b/test/lang/overloads/declmismatch/param/1-2v/compilererr.txt
@@ -1,0 +1,1 @@
+overload has more parameters \(2\+\) than declaration \(1\)

--- a/test/lang/overloads/declmismatch/param/1-2v/main.clay
+++ b/test/lang/overloads/declmismatch/param/1-2v/main.clay
@@ -1,0 +1,5 @@
+define foo(a);
+
+overload foo(a, b, ..c) = 1;
+
+main() {}

--- a/test/lang/overloads/declmismatch/param/2-0/compilererr.txt
+++ b/test/lang/overloads/declmismatch/param/2-0/compilererr.txt
@@ -1,0 +1,1 @@
+overload has fewer parameters \(0\) than declaration \(2\)

--- a/test/lang/overloads/declmismatch/param/2-0/main.clay
+++ b/test/lang/overloads/declmismatch/param/2-0/main.clay
@@ -1,0 +1,5 @@
+define foo(a, b);
+
+overload foo() = 1;
+
+main() {}

--- a/test/lang/overloads/declmismatch/param/2v-0/compilererr.txt
+++ b/test/lang/overloads/declmismatch/param/2v-0/compilererr.txt
@@ -1,0 +1,1 @@
+overload has fewer parameters \(0\) than declaration \(2\+\)

--- a/test/lang/overloads/declmismatch/param/2v-0/main.clay
+++ b/test/lang/overloads/declmismatch/param/2v-0/main.clay
@@ -1,0 +1,5 @@
+define foo(a, b, ..c);
+
+overload foo() = 1;
+
+main() {}

--- a/test/lang/overloads/declmismatch/return/1-2/compilererr.txt
+++ b/test/lang/overloads/declmismatch/return/1-2/compilererr.txt
@@ -1,0 +1,1 @@
+overload return count \(2\) must be equal to define return count \(1\)

--- a/test/lang/overloads/declmismatch/return/1-2/main.clay
+++ b/test/lang/overloads/declmismatch/return/1-2/main.clay
@@ -1,0 +1,5 @@
+define foo(a): Int;
+
+overload foo(a): Int, Int = 1, 2;
+
+main() {}

--- a/test/lang/overloads/declmismatch/return/2-0/compilererr.txt
+++ b/test/lang/overloads/declmismatch/return/2-0/compilererr.txt
@@ -1,0 +1,1 @@
+overload return count \(0\) must be equal to define return count \(2\)

--- a/test/lang/overloads/declmismatch/return/2-0/main.clay
+++ b/test/lang/overloads/declmismatch/return/2-0/main.clay
@@ -1,0 +1,5 @@
+define foo(a): Int, Int;
+
+overload foo(a): {}
+
+main() {}


### PR DESCRIPTION
```
define foo(a);
overload foo(a, b) = 1;
```

is error now even if `foo` is not called.
