### PR TITLE
compiler: do not catch any std::exception

### DIFF
--- a/compiler/clay.cpp
+++ b/compiler/clay.cpp
@@ -1202,7 +1202,7 @@ int main2(int argc, char **argv, char const* const* envp) {
             if (!result)
                 return 1;
         }
-    } catch (std::exception) {
+    } catch (const CompilerError&) {
         return 1;
     }
     if (showTiming) {

--- a/compiler/clay.hpp
+++ b/compiler/clay.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <exception>
 #include <map>
 #include <set>
 #include <iomanip>
@@ -4078,6 +4079,10 @@ typedef Pointer<ExternalTarget> ExternalTargetPtr;
 
 void initExternalTarget(string target);
 ExternalTargetPtr getExternalTarget();
+
+
+class CompilerError : std::exception {
+};
 
 //
 // parachute

--- a/compiler/error.cpp
+++ b/compiler/error.cpp
@@ -273,7 +273,7 @@ void note(llvm::Twine const &msg) {
 
 void error(llvm::Twine const &msg) {
     displayError(msg, "error");
-    throw(std::exception());
+    throw CompilerError();
 }
 
 void error(Location const &location, llvm::Twine const &msg) {


### PR DESCRIPTION
std::bad_alloc should not be handled the same way as compiler error
