### PR TITLE
Repl: catch CompilerError instead of std::expection

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -63,7 +63,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInf
 else()
     set(CLAY_CXXFLAGS "${LLVM_CXXFLAGS} -DNDEBUG")
 endif()
-set(CLAY_CXXFLAGS "${CLAY_CXXFLAGS} -fexceptions")
+if (NOT MSVC)
+    set(CLAY_CXXFLAGS "${CLAY_CXXFLAGS} -fexceptions")
+endif()
 
 set(ENABLE_PCH False CACHE BOOL
     "Use precompiled headers when building the compiler. (experimental)")

--- a/compiler/interactive.cpp
+++ b/compiler/interactive.cpp
@@ -1,15 +1,12 @@
 #include "clay.hpp"
 #include "lexer.hpp"
 #include "codegen.hpp"
+#include "error.hpp"
 #include "loader.hpp"
-
 
 #include <setjmp.h>
 #include <signal.h>
 #include <stdio.h>
-
-#include <llvm/Target/TargetOptions.h>
-
 
 namespace clay {
 
@@ -170,13 +167,13 @@ namespace clay {
                 vector<ImportPtr> imports;
                 try {
                     parseInteractive(source, 0, source->size(), toplevels, imports, stmts);
+                    loadImports(imports);
+                    jitTopLevel(toplevels);
+                    jitStatements(stmts);
                 }
-                catch (std::exception) {
+                catch (CompilerError) {
                     continue;
                 }
-                loadImports(imports);
-                jitTopLevel(toplevels);
-                jitStatements(stmts);
             }
         }
         engine->runStaticConstructorsDestructors(true);


### PR DESCRIPTION
Repl: catch CompilerError instead of std::expection
Hide -fexceptions warnings in VS

Still bugs:
- SIGABRT recovery in MSVS is sill buggy. MSDN says that you can recover with longjmp, but after one catched SIGABRT another starts the debugger. `__except` can't catch SIGABRT
- Noticed not full recovery after exception, perhaps some module state becomes undefined after an error:

```
g:/clay/build/compiler>clay ..\..\examples\factorial.clay -repl
clay>factorial1(123123123123);
(1,11): error: int32 literal out of range
clay>factorial1(1);
(1,11): error: int32 literal out of range
```

factorial1(1) is not out of range
