### PR TITLE
lambda capture overloads

### DIFF
--- a/compiler/clay.cpp
+++ b/compiler/clay.cpp
@@ -558,6 +558,8 @@ int main2(int argc, char **argv, char const* const* envp) {
     unsigned optLevel = 2;
     bool optLevelSet = false;
 
+    setOnlyOverloadedLambdas(false);
+
 #ifdef __APPLE__
     genPIC = true;
 
@@ -621,6 +623,12 @@ int main2(int argc, char **argv, char const* const* envp) {
             optLevel = 3;
             optLevelSet = true;
         }
+        else if (strcmp(argv[i], "-only-overloaded-lambdas") == 0) {
+            setOnlyOverloadedLambdas(true);
+        }
+        else if (strcmp(argv[i], "-no-only-overloaded-lambdas") == 0) {
+            setOnlyOverloadedLambdas(false);
+        }
         else if (strcmp(argv[i], "-inline") == 0) {
             inlineEnabled = true;
         }
@@ -631,8 +639,6 @@ int main2(int argc, char **argv, char const* const* envp) {
             exceptions = true;
         }
         else if (strcmp(argv[i], "-no-exceptions") == 0) {
-
-
             exceptions = false;
         }
         else if (strcmp(argv[i], "-pic") == 0) {

--- a/compiler/clay.hpp
+++ b/compiler/clay.hpp
@@ -1256,7 +1256,8 @@ struct ProcedureMono {
 enum LambdaCapture {
     REF_CAPTURE,
     VALUE_CAPTURE,
-    STATELESS
+    STATELESS,
+    OVERLOADED
 };
 
 struct Lambda : public Expr {
@@ -1278,6 +1279,9 @@ struct Lambda : public Expr {
     // if freevars are absent
     ProcedurePtr lambdaProc;
 
+    //if LambdaCapture == OVERLOADED
+    StringLiteralPtr hook;
+
     bool hasVarArg:1;
     bool initialized:1;
 
@@ -1289,6 +1293,12 @@ struct Lambda : public Expr {
            bool hasVarArg, StatementPtr body)
         : Expr(LAMBDA), captureBy(captureBy),
           formalArgs(formalArgs), body(body),
+          hasVarArg(hasVarArg), initialized(false) {}
+    Lambda(LambdaCapture captureBy,
+           llvm::ArrayRef<FormalArgPtr> formalArgs,
+           bool hasVarArg, StatementPtr body, StringLiteralPtr hook)
+        : Expr(LAMBDA), captureBy(captureBy),
+          formalArgs(formalArgs), body(body), hook(hook),
           hasVarArg(hasVarArg), initialized(false) {}
 };
 
@@ -2493,6 +2503,7 @@ struct MultiPValue : public Object {
 // parser module
 //
 
+void setOnlyOverloadedLambdas(bool value);
 
 enum ParserFlags
 {

--- a/compiler/clone.cpp
+++ b/compiler/clone.cpp
@@ -161,6 +161,7 @@ ExprPtr clone(ExprPtr x)
         LambdaPtr z = new Lambda(y->captureBy);
         clone(y->formalArgs, z->formalArgs);
         z->hasVarArg = y->hasVarArg;
+        z->hook = y->hook.ptr();
         z->body = clone(y->body);
         out = z.ptr();
         break;

--- a/compiler/lambdas.cpp
+++ b/compiler/lambdas.cpp
@@ -11,14 +11,16 @@ namespace clay {
 
 struct LambdaContext {
     LambdaCapture captureBy;
+    StringLiteralPtr hook;
     EnvPtr nonLocalEnv;
     llvm::StringRef closureDataName;
     vector<string> &freeVars;
     LambdaContext(LambdaCapture captureBy,
+                  StringLiteralPtr hook,
                   EnvPtr nonLocalEnv,
                   llvm::StringRef closureDataName,
                   vector<string> &freeVars)
-        : captureBy(captureBy), nonLocalEnv(nonLocalEnv),
+        : captureBy(captureBy), hook(hook), nonLocalEnv(nonLocalEnv),
           closureDataName(closureDataName), freeVars(freeVars) {}
 };
 
@@ -98,12 +100,13 @@ void initializeLambda(LambdaPtr x, EnvPtr env)
     llvm::SmallString<128> buf;
     llvm::raw_svector_ostream ostr(buf);
     ostr << "%closureData:" << lname;
-    string closureDataName = ostr.str();
 
+    string closureDataName = ostr.str();
     convertFreeVars(x, env, closureDataName, x->freeVars);
     getProcedureMonoTypes(x->mono, env, x->formalArgs, x->hasVarArg);
-        
+
     switch (x->captureBy) {
+    case OVERLOADED:
     case REF_CAPTURE :
     case VALUE_CAPTURE : {
         if (x->freeVars.empty()) {
@@ -216,9 +219,20 @@ static void initializeLambdaWithFreeVars(LambdaPtr x, EnvPtr env,
     TypePtr t = recordType(r, vector<ObjectPtr>());
     x->lambdaType = t;
     ExprPtr typeExpr = new ObjectExpr(t.ptr());
-    converted->expr = typeExpr;
-    x->converted = converted.ptr();
+    
+    if (x->captureBy == OVERLOADED) {
+        converted->expr = new NameRef(Identifier::get("lambdaPack"));
+        converted->parenArgs->insert(new StaticExpr(typeExpr));
+        converted->parenArgs->insert(new StaticExpr(x->hook.ptr()));
+        ExprPtr conv = static_cast<Expr*>(converted.ptr());
+        TypePtr t =  safeAnalyzeOne(conv, env).type;
+        typeExpr = new ObjectExpr(t.ptr());
+    } else {
+        converted->expr = typeExpr;
+    }
 
+    x->converted = converted.ptr();
+  
     CodePtr code = new Code();
     code->location = x->location;
     IdentifierPtr closureDataIdent = Identifier::get(closureDataName);
@@ -228,8 +242,27 @@ static void initializeLambdaWithFreeVars(LambdaPtr x, EnvPtr env,
         code->formalArgs.push_back(x->formalArgs[i]);
     }
     code->hasVarArg = x->hasVarArg;
-    code->body = x->body;
+    if (x->captureBy == OVERLOADED) {    
+        BlockPtr bodyWithBindings = new Block();
 
+        vector<FormalArgPtr> left;
+        for (unsigned i = 0; i < x->freeVars.size(); i++) {
+            left.push_back(new FormalArg(Identifier::get(x->freeVars[i]), 
+                                         fields[i]->type));
+        }
+        
+        ExprPtr lambdaUnpack = new NameRef(Identifier::get("lambdaUnpack"));
+        ExprListPtr args = new ExprList();
+        args->exprs.push_back(new StaticExpr(x->hook.ptr()));
+        args->exprs.push_back(new NameRef(closureDataIdent));
+        ExprListPtr right = new ExprList(new Unpack(new Call(lambdaUnpack, args)));
+
+        bodyWithBindings->statements.push_back(new Binding(FORWARD, left, right));
+        bodyWithBindings->statements.push_back(x->body);
+        code->body = static_cast<Statement*>(bodyWithBindings.ptr());
+    } else {
+        code->body = x->body;
+    }
     OverloadPtr overload = new Overload(
         NULL, operator_expr_call(), code, false, IGNORE
     );
@@ -297,7 +330,7 @@ void convertFreeVars(LambdaPtr x, EnvPtr env,
         FormalArgPtr arg = x->formalArgs[i];
         addLocal(env2, arg->name, arg->name.ptr());
     }
-    LambdaContext ctx(x->captureBy, env, closureDataName, freeVars);
+    LambdaContext ctx(x->captureBy, x->hook, env, closureDataName, freeVars);
     convertFreeVars(x->body, env2, ctx);
 }
 
@@ -542,12 +575,18 @@ void convertFreeVars(ExprPtr &x, EnvPtr env, LambdaContext &ctx)
                 }
                 else {
                     addFreeVar(ctx, y->name->str);
+                    if (ctx.captureBy == OVERLOADED) {
+                        break;
+                    }
                     IdentifierPtr a = Identifier::get(ctx.closureDataName, y->location);
                     NameRefPtr b = new NameRef(a);
                     b->location = y->location;
                     FieldRefPtr c = new FieldRef(b.ptr(), y->name);
                     c->location = y->location;
                     switch (ctx.captureBy) {
+                    case OVERLOADED : {
+                        break;
+                    }
                     case REF_CAPTURE : {
                         ExprPtr d = new VariadicOp(DEREFERENCE, new ExprList(c.ptr()));
                         d->location = y->location;
@@ -585,12 +624,18 @@ void convertFreeVars(ExprPtr &x, EnvPtr env, LambdaContext &ctx)
                 }
                 else {
                     addFreeVar(ctx, y->name->str);
+                    if (ctx.captureBy == OVERLOADED) {
+                        break;
+                    }
                     IdentifierPtr a = Identifier::get(ctx.closureDataName, y->location);
                     NameRefPtr b = new NameRef(a);
                     b->location = y->location;
                     FieldRefPtr c = new FieldRef(b.ptr(), y->name);
                     c->location = y->location;
                     switch (ctx.captureBy) {
+                    case OVERLOADED : {
+                        break;
+                    }
                     case REF_CAPTURE : {
                         ExprPtr f =
                             operator_expr_unpackMultiValuedFreeVarAndDereference();

--- a/lib-clay/core/core.clay
+++ b/lib-clay/core/core.clay
@@ -17,6 +17,7 @@ public import core.values.*;
 public import core.maybe.*;
 public import core.variants.*;
 public import core.variants.nested.*;
+public import core.lambdas.*;
 
 public import core.arrays.*;
 public import core.coordinates.*;

--- a/lib-clay/core/lambdas/lambdas.clay
+++ b/lib-clay/core/lambdas/lambdas.clay
@@ -1,0 +1,30 @@
+public define lambdaPack;
+public define lambdaUnpack;
+
+record Lambda[L, T](closures: T);
+
+packMultiValuedFreeVarByMove(..x) = Tuple(..mapValues(move, ..x));
+
+[L]
+mkLambda(#L, data) = Lambda[#L, Type(data)](data);
+
+[L]
+forceinline overload lambdaPack(#"val", #L, ..xs) =
+    mkLambda(#L, packMultiValuedFreeVar(..xs));
+
+forceinline overload lambdaUnpack(#"val", xs) = 
+    forward ..unpackMultiValuedFreeVar(xs.closures);
+
+[L]
+forceinline overload lambdaPack(#"byref", #L, ..xs) =
+    mkLambda(#L, packMultiValuedFreeVarByRef(..xs));
+
+forceinline overload lambdaUnpack(#"byref", xs) =
+    forward ..unpackMultiValuedFreeVarAndDereference(xs.closures);
+
+[L]
+forceinline overload lambdaPack(#"move", #L, ..xs) = 
+    mkLambda(#L, packMultiValuedFreeVarByMove(..xs));
+
+forceinline overload lambdaUnpack(#"move", xs) =
+    forward ..unpackMultiValuedFreeVar(xs.closures);

--- a/test/lib-clay/lambdas/overloaded/main.clay
+++ b/test/lib-clay/lambdas/overloaded/main.clay
@@ -1,0 +1,16 @@
+import printer.(println);
+import vectors.(Vector);
+
+main(){
+    var v = Vector(array(1,2));
+    var byVal = x ::val> v[0] + x + 1;
+    var byVal2 = x ::val> v[1] + x + 2;
+    var byRef = x ::byref> v[0] + x;
+    v[0] = 5;
+    println("byVal: ", byVal(0));
+    println("byVal2: ", byVal2(0));
+    println("byRef: ", byRef(0));
+    var byMove = x ::move> v[0] + x;
+    println("byMove: ", byMove(0));
+    println("v: ", v);
+}

--- a/test/lib-clay/lambdas/overloaded/out.txt
+++ b/test/lib-clay/lambdas/overloaded/out.txt
@@ -1,0 +1,5 @@
+byVal: 2
+byVal2: 4
+byRef: 5
+byMove: 5
+v: {}


### PR DESCRIPTION
Make possible to change values while capturing by overloading `lambdaRepack` and `lambdaUnpack`.

```
var v = vector(array(1,2,3,4,5));
var f = x :move> v[0] + 1;
println(v);//prints empty an vector, because data was moved to the closure
```
