### PR TITLE
Remove alignment utilities

### DIFF
--- a/lib-clay/core/memory/memory.clay
+++ b/lib-clay/core/memory/memory.clay
@@ -1,4 +1,3 @@
-import core.memory.platform.(SystemMallocAlignment);
 import core.libc as libc;
 
 
@@ -44,46 +43,10 @@ freeArray(array:CoordinateRange[T]) {
 }
 
 
-/// @section  alignedMalloc, alignedFree 
-
-alignedMalloc(numBytes:SizeT, alignment:SizeT) {
-    var ptr = libc.malloc(numBytes + alignment + TypeSize(UInt8));
-    if (null?(ptr))
-        return null(UInt8);
-    var mask = bitnot(SizeT(alignment) - 1);
-    var roundedDown = bitand(SizeT(ptr), mask);
-    var alignedPtr = Pointer[UInt8](alignment + roundedDown);
-    (alignedPtr - 1)^ = Byte(alignedPtr - ptr);
-    return alignedPtr;
-}
-
-alignedFree(ptr:Pointer[UInt8]) {
-    if (null?(ptr))
-        return;
-    var offset = SizeT((ptr-1)^);
-    var originalPtr = ptr - offset;
-    libc.free(originalPtr);
-}
-
-
-/// @section  allocateRawMemoryAligned, freeRawMemoryAligned 
-
-[T, I, J when Integer?(I) and Integer?(J)]
-allocateRawMemoryAligned(#T, count:I, alignment:J) {
-    var ptr = alignedMalloc(TypeSize(T) * SizeT(count), SizeT(alignment));
-    return Pointer[T](ptr);
-}
-
-[T]
-freeRawMemoryAligned(ptr:Pointer[T]) {
-    alignedFree(Pointer[UInt8](ptr));
-}
-
-
-
 /// @section  allocateRawMemory, freeRawMemory 
 
-define allocateRawMemory;
+[T,I when Integer?(I)]
+define allocateRawMemory(#T, count:I): Pointer[T];
 
 [T,I when Integer?(I)]
 overload allocateRawMemory(#T, count:I) {
@@ -91,29 +54,16 @@ overload allocateRawMemory(#T, count:I) {
     return Pointer[T](ptr);
 }
 
-[T,I when Integer?(I) and TypeAlignment(T) <= SystemMallocAlignment]
+[T,I when Integer?(I)]
 reallocateRawMemory(ptr:Pointer[T], count:I) {
     var newptr = libc.realloc(RawPointer(ptr), TypeSize(T) * SizeT(count));
     return Pointer[T](newptr);
 }
 
-define freeRawMemory;
-
 [T]
-overload freeRawMemory(ptr:Pointer[T]) {
+freeRawMemory(ptr:Pointer[T]) {
     libc.free(RawPointer(ptr));
 }
-
-[T,I when Integer?(I) and (TypeAlignment(T) > SystemMallocAlignment)]
-overload allocateRawMemory(#T, count:I) {
-    return allocateRawMemoryAligned(T, count, TypeAlignment(T));
-}
-
-[T when TypeAlignment(T) > SystemMallocAlignment]
-overload freeRawMemory(ptr:Pointer[T]) {
-    freeRawMemoryAligned(ptr);
-}
-
 
 
 /// @section  initializeMemory 

--- a/lib-clay/core/memory/platform/platform.clay
+++ b/lib-clay/core/memory/platform/platform.clay
@@ -1,2 +1,0 @@
-
-alias SystemMallocAlignment = 8;

--- a/lib-clay/core/memory/platform/platform.macosx.clay
+++ b/lib-clay/core/memory/platform/platform.macosx.clay
@@ -1,2 +1,0 @@
-
-alias SystemMallocAlignment = 16;

--- a/lib-clay/data/any/any.clay
+++ b/lib-clay/data/any/any.clay
@@ -21,7 +21,6 @@ record Any (
     id : Int,
     ptr : Pointer[Byte],
     size : SizeT,
-    alignment : SizeT,
     copyConstructor : CodePointer[[Opaque], [Opaque]],
     destructor : CodePointer[[Opaque], []],
 );
@@ -34,26 +33,24 @@ overload Any() {
         -1,
         null(Byte),
         SizeT(0),
-        SizeT(0),
         CodePointer[[Opaque],[Opaque]](0),
         CodePointer[[Opaque],[]](0)
     );
 }
 
 overload Any(x:Any) {
-    var ptr = allocateRawMemoryAligned(Byte, x.size, x.alignment);
+    var ptr = allocateRawMemory(Byte, x.size);
     try {
         ptr^ <-- x.copyConstructor(x.ptr^);
     }
     catch (e) {
-        freeRawMemoryAligned(ptr);
+        freeRawMemory(ptr);
         throw e;
     }
     return Any(
         x.id,
         ptr,
         x.size,
-        x.alignment,
         x.copyConstructor,
         x.destructor
     );
@@ -68,7 +65,7 @@ overload resetUnsafe(x:Any) {
 overload destroy(x:Any) {
     if (not null?(x.ptr)) {
         x.destructor(x.ptr^);
-        freeRawMemoryAligned(x.ptr);
+        freeRawMemory(x.ptr);
     }
 }
 
@@ -80,12 +77,12 @@ overload assign(ref dest:Any, ref src:Any) {
 
 [T]
 alias box(x:T) {
-    var ptr = allocateRawMemoryAligned(Byte, TypeSize(T), TypeAlignment(T));
+    var ptr = allocateRawMemory(Byte, TypeSize(T));
     try {
         Pointer[T](ptr)^ <-- x;
     }
     catch (e) {
-        freeRawMemoryAligned(ptr);
+        freeRawMemory(ptr);
         throw e;
     }
     var copyConstructor = makeCodePointer(T, T);
@@ -94,7 +91,6 @@ alias box(x:T) {
         typeId[T],
         Pointer[Byte](ptr),
         TypeSize(T),
-        TypeAlignment(T),
         CodePointer[[Opaque],[Opaque]](copyConstructor),
         CodePointer[[Opaque],[]](destructor)
     );

--- a/lib-clay/lambdas/lambdas.clay
+++ b/lib-clay/lambdas/lambdas.clay
@@ -97,12 +97,12 @@ alias overload FunctionBody[[..I],[..O]](x:T) --> returned:FunctionBody[[..I],[.
     returned.code = CodePointer[[Opaque, ..I], [..O]](codePtr);
     returned.destructor = CodePointer[[Opaque],[]](destructor);
 
-    var ptr = allocateRawMemoryAligned(T, 1, TypeAlignment(T));
+    var ptr = allocateRawMemory(T, 1);
     try {
         ptr^ <-- x;
     }
     catch (e) {
-        freeRawMemoryAligned(ptr);
+        freeRawMemory(ptr);
         throw e;
     }
     returned.obj = Pointer[Opaque](ptr);
@@ -111,6 +111,6 @@ alias overload FunctionBody[[..I],[..O]](x:T) --> returned:FunctionBody[[..I],[.
 [In, Out]
 overload destroy(x:FunctionBody[In, Out]) {
     x.destructor(x.obj^);
-    freeRawMemoryAligned(x.obj);
+    freeRawMemory(x.obj);
 }
 

--- a/lib-clay/twohash/implementation/implementation.clay
+++ b/lib-clay/twohash/implementation/implementation.clay
@@ -89,7 +89,7 @@ overload TwoHash[E]()
 overload Table[B](ln2_size: Int) 
 {
     var size = bitshl(SizeT(1), ln2_size);
-    var ptr = allocateRawMemoryAligned(B, size, 16);
+    var ptr = allocateRawMemory(B, size);
     initializeMemory(ptr, ptr+size);
     return Table[B](ptr, ln2_size);
 }
@@ -133,7 +133,7 @@ overload destroy(t: Table[B])
     if (not null?(t.ptr))
     {
         destroyMemory(t.ptr, t.ptr+size(t));
-        freeRawMemoryAligned(t.ptr);
+        freeRawMemory(t.ptr);
     }
 }
 

--- a/test/lang/codepointers/30/main.clay
+++ b/test/lang/codepointers/30/main.clay
@@ -26,7 +26,6 @@ overload display(x) {
 record Displayable (
     obj : Pointer[Opaque],
     size : SizeT,
-    alignment : SizeT,
     destructor : CodePointer[[Opaque],[]],
     copyConstructor : CodePointer[[Opaque],[Opaque]],
     display : CodePointer[[Opaque],[]],
@@ -38,7 +37,7 @@ overload RegularRecord?(#Displayable) = false;
 // primary constructor
 [T]
 overload Displayable(x:T) {
-    var obj = allocateRawMemoryAligned(T, 1, TypeAlignment(T));
+    var obj = allocateRawMemory(T, 1);
     obj^ <-- x;
     var destructor = makeCodePointer(destroy, T);
     var copyConstructor = makeCodePointer(T, T);
@@ -46,7 +45,6 @@ overload Displayable(x:T) {
 
     return Displayable(Pointer[Opaque](obj),
                        TypeSize(T),
-                       TypeAlignment(T),
                        CodePointer[[Opaque],[]](destructor),
                        CodePointer[[Opaque],[Opaque]](copyConstructor),
                        CodePointer[[Opaque],[]](displayPtr));
@@ -54,7 +52,7 @@ overload Displayable(x:T) {
 
 // default constructor
 overload Displayable() {
-    return Displayable(null(Opaque), SizeT(0), SizeT(0),
+    return Displayable(null(Opaque), SizeT(0),
                        CodePointer[[Opaque],[]](0),
                        CodePointer[[Opaque],[Opaque]](0),
                        CodePointer[[Opaque],[]](0));
@@ -62,10 +60,10 @@ overload Displayable() {
 
 // copy constructor
 overload Displayable(x:Displayable) {
-    var p = allocateRawMemoryAligned(Int8, x.size, x.alignment);
+    var p = allocateRawMemory(Int8, x.size);
     var obj = Pointer[Opaque](p);
     obj^ <-- x.copyConstructor(x.obj^);
-    return Displayable(obj, x.size, x.alignment,
+    return Displayable(obj, x.size,
                        x.destructor, x.copyConstructor, x.display);
 }
 
@@ -74,7 +72,6 @@ overload moveUnsafe(src:Displayable) --> returned:Displayable {
     returned <-- Displayable(
         src.obj,
         src.size,
-        src.alignment,
         src.destructor,
         src.copyConstructor,
         src.display
@@ -90,7 +87,7 @@ overload resetUnsafe(x:Displayable) {
 overload destroy(x:Displayable) {
     if (not null?(x.obj)) {
         x.destructor(x.obj^);
-        freeRawMemoryAligned(x.obj);
+        freeRawMemory(x.obj);
     }
 }
 

--- a/test/lang/codepointers/31/main.clay
+++ b/test/lang/codepointers/31/main.clay
@@ -25,7 +25,6 @@ overload display(x) {
 
 record DisplayableVTable (
     size : SizeT,
-    alignment : SizeT,
     destructor : CodePointer[[Opaque],[]],
     copyConstructor : CodePointer[[Opaque],[Opaque]],
     display : CodePointer[[Opaque],[]],
@@ -37,7 +36,6 @@ makeDisplayableVTable(#T) {
     var copyConstructor = makeCodePointer(T, T);
     var display = makeCodePointer(display, T);
     return DisplayableVTable(TypeSize(T),
-                             TypeAlignment(T),
                              CodePointer[[Opaque],[]](destructor),
                              CodePointer[[Opaque],[Opaque]](copyConstructor),
                              CodePointer[[Opaque],[]](display));
@@ -59,7 +57,7 @@ overload RegularRecord?(#Displayable) = false;
 // constructor
 [T]
 overload Displayable(x:T) {
-    var obj = allocateRawMemoryAligned(T, 1, TypeAlignment(T));
+    var obj = allocateRawMemory(T, 1);
     obj^ <-- x;
     var vtable = allocateRawMemory(DisplayableVTable, 1);
     vtable^ <-- makeDisplayableVTable(T);
@@ -74,7 +72,7 @@ overload Displayable(x:Displayable) {
     if (null?(x.obj))
         return Displayable();
     var vt = x.vtable;
-    var p = allocateRawMemoryAligned(Int8, vt^.size, vt^.alignment);
+    var p = allocateRawMemory(Int8, vt^.size);
     var obj = Pointer[Opaque](p);
     obj^ <-- vt^.copyConstructor(x.obj^);
     var vtable = allocateRawMemory(DisplayableVTable, 1);
@@ -96,7 +94,7 @@ overload resetUnsafe(x:Displayable) {
 overload destroy(x:Displayable) {
     if (not null?(x.obj)) {
         x.vtable^.destructor(x.obj^);
-        freeRawMemoryAligned(x.obj);
+        freeRawMemory(x.obj);
         freeRawMemory(x.vtable);
     }
 }

--- a/test/lang/codepointers/32/main.clay
+++ b/test/lang/codepointers/32/main.clay
@@ -37,7 +37,6 @@ overload display(a:Vector[T]) {
 record Displayable (
     obj : Pointer[Opaque],
     size : SizeT,
-    alignment : SizeT,
     destructor : CodePointer[[Opaque],[]],
     copyConstructor : CodePointer[[Opaque],[Opaque]],
     display : CodePointer[[Opaque],[]],
@@ -49,7 +48,7 @@ overload RegularRecord?(#Displayable) = false;
 // primary constructor
 [T]
 overload Displayable(x:T) {
-    var obj = allocateRawMemoryAligned(T, 1, TypeAlignment(T));
+    var obj = allocateRawMemory(T, 1);
     obj^ <-- x;
     var destructor = makeCodePointer(destroy, T);
     var copyConstructor = makeCodePointer(T, T);
@@ -57,7 +56,6 @@ overload Displayable(x:T) {
 
     return Displayable(Pointer[Opaque](obj),
                        TypeSize(T),
-                       TypeAlignment(T),
                        CodePointer[[Opaque],[]](destructor),
                        CodePointer[[Opaque],[Opaque]](copyConstructor),
                        CodePointer[[Opaque],[]](displayPtr));
@@ -65,7 +63,7 @@ overload Displayable(x:T) {
 
 // default constructor
 overload Displayable() {
-    return Displayable(null(Opaque), SizeT(0), SizeT(0),
+    return Displayable(null(Opaque), SizeT(0),
                        CodePointer[[Opaque],[]](0),
                        CodePointer[[Opaque],[Opaque]](0),
                        CodePointer[[Opaque],[]](0));
@@ -73,10 +71,10 @@ overload Displayable() {
 
 // copy constructor
 overload Displayable(x:Displayable) {
-    var p = allocateRawMemoryAligned(Int8, x.size, x.alignment);
+    var p = allocateRawMemory(Int8, x.size);
     var obj = Pointer[Opaque](p);
     obj^ <-- x.copyConstructor(x.obj^);
-    return Displayable(obj, x.size, x.alignment,
+    return Displayable(obj, x.size,
                        x.destructor, x.copyConstructor, x.display);
 }
 
@@ -85,7 +83,6 @@ overload moveUnsafe(src:Displayable) --> returned:Displayable {
     returned <-- Displayable(
         src.obj,
         src.size,
-        src.alignment,
         src.destructor,
         src.copyConstructor,
         src.display
@@ -101,7 +98,7 @@ overload resetUnsafe(x:Displayable) {
 overload destroy(x:Displayable) {
     if (not null?(x.obj)) {
         x.destructor(x.obj^);
-        freeRawMemoryAligned(x.obj);
+        freeRawMemory(x.obj);
     }
 }
 


### PR DESCRIPTION
libc.malloc already returns memory "suitably aligned so that it may
be assigned to a pointer to any type of object"

http://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html

Same is true for MS malloc:

http://msdn.microsoft.com/en-us/library/aa246461%28v=vs.60%29.aspx
