### PR TITLE
tempCString utility

### DIFF
--- a/lib-clay/data/strings/tempcstrings/tempcstrings.clay
+++ b/lib-clay/data/strings/tempcstrings/tempcstrings.clay
@@ -1,0 +1,46 @@
+import data.strings.*;
+
+
+[Owned when Type(Owned) == Bool]
+record CStringHolder[Owned] (
+    cstring: CStringRef,
+);
+
+[Owned]
+overload fieldRef(s: CStringHolder[Owned], #"ptr") = s.cstring.ptr;
+
+[Owned]
+overload PODType?(#CStringHolder[Owned]) = false;
+[Owned]
+overload RegularRecord?(#CStringHolder[Owned]) = false;
+[Owned]
+overload BitwiseMovedType?(#CStringHolder[Owned]) = true;
+
+[Owned]
+overload resetUnsafe(s: CStringHolder[Owned]) {
+    s.cstring = CStringRef();
+}
+
+[Owned]
+overload destroy(holder: CStringHolder[Owned]) {
+    if (#Owned) {
+        libc.free(holder.cstring.ptr);
+    }
+}
+
+staticassert(     Movable?(CStringHolder[ #true]));
+staticassert(not Copyable?(CStringHolder[ #true]));
+staticassert(     Movable?(CStringHolder[#false]));
+staticassert(not Copyable?(CStringHolder[#false]));
+
+[S when String?(S)]
+tempCString(s: S) {
+    if (#CCompatibleString?(S)) {
+        return CStringHolder[#false](CStringRef(s));
+    } else {
+        var string = String(s);
+        cstring(string); // add trailing \0
+        return CStringHolder[ #true](CStringRef(moveVectorBuffer(string)));
+    }
+}
+

--- a/lib-clay/io/sockets/sockets.clay
+++ b/lib-clay/io/sockets/sockets.clay
@@ -5,6 +5,7 @@ import printer.(printTo,printReprTo);
 import io.files.*;
 import io.streams.*;
 import data.strings.*;
+import data.strings.tempcstrings.*;
 import libc;
 import data.sequences.*;
 
@@ -133,9 +134,9 @@ instance SocketError (HostnameLookupError);
 [S when String?(S) and S != String]
 overload HostnameLookupError(name: S) = HostnameLookupError(String(name));
 
-[S when CCompatibleString?(S)]
+[S when String?(S)]
 overload lookupInetHostname(hostname: S) {
-    var hostent = platform.gethostbyname(cstring(hostname));
+    var hostent = platform.gethostbyname(tempCString(hostname).ptr);
     if (null?(hostent))
         throw HostnameLookupError(hostname);
     if (hostent^.h_addrtype != AF_INET

--- a/lib-clay/numbers/parser/parser.clay
+++ b/lib-clay/numbers/parser/parser.clay
@@ -3,6 +3,7 @@ import numbers.parser.errno.*;
 import printer.(error);
 import printer.formatter.(repr);
 import data.strings.*;
+import data.strings.tempcstrings.*;
 import libc;
 import data.sequences.*;
 
@@ -35,15 +36,11 @@ overload ConvFuncForType(#T) = ConvFuncForType(ImagBaseType(T));
 define parse(#T, s:S): T;
 
 
-[T when Integer?(T) or Float?(T) or Imaginary?(T)]
-overload parse(T, s) =
-    parse(T, String(s));
-
-
-[S, IntType when CCompatibleString?(S) and Integer?(IntType)]
+[S, IntType when String?(S) and Integer?(IntType)]
 overload parse(#IntType, s:S) {
     alias convFunc = ConvFuncForType(IntType);
-    var p = cstring(s);
+    var temp = tempCString(s);
+    var p = temp.ptr;
     var end = null(CChar);
     var value = convFunc(p, @end, 0);
     var typeName = StaticName(IntType);
@@ -54,10 +51,11 @@ overload parse(#IntType, s:S) {
     return IntType(value);
 }
 
-[S, FloatType when CCompatibleString?(S) and Float?(FloatType)]
+[S, FloatType when String?(S) and Float?(FloatType)]
 overload parse(#FloatType, s:S) {
     alias convFunc = ConvFuncForType(FloatType);
-    var p = cstring(s);
+    var temp = tempCString(s);
+    var p = temp.ptr;
     var end = null(CChar);
     var value = convFunc(p, @end);
     var typeName = StaticName(FloatType);
@@ -68,10 +66,11 @@ overload parse(#FloatType, s:S) {
     return FloatType(value);
 }
 
-[S, ImagType when CCompatibleString?(S) and Imaginary?(ImagType)]
+[S, ImagType when String?(S) and Imaginary?(ImagType)]
 overload parse(#ImagType, s:S) {
     alias convFunc = ConvFuncForType(ImagType);
-    var p = cstring(s);
+    var temp = tempCString(s);
+    var p = temp.ptr;
     var end = null(CChar);
     var value = convFunc(p, @end);
     var typeName = StaticName(ImagType);


### PR DESCRIPTION
`tempCString` produces C string for given string. Result is wrapped
in CStringHolder record.

If input is already a C string, then input is simply stored in a
POD CStringHolder.

If input is a string but not a C string, then memory for C string
is allocated, string data is copied to that string, and allocated
C string is stored in CStringHolder record.  In this case CStringHolder
owns cstring reference and releases it on destroy.

tempCString is convenient to call C APIs that accept
C strings. Code example:

```
mysqlConnect(host: Pointer[Byte]) { ... }

[S when String?(S)]
myCode(host: S) = mysqlConnect(tempCString(host).ptr);
```

Currently memory is allocated using malloc. Later tempCString may
be rewritten to allocate memory in a thread-local fixed size memory
chunk pool (in this case the cost of memory allocation will be
comparable to `alloca`).
