### PR TITLE
Extract  parser.hpp from clay.hpp. Multi-line input for repl

### DIFF
--- a/compiler/clay.cpp
+++ b/compiler/clay.cpp
@@ -1096,11 +1096,11 @@ int main2(int argc, char **argv, char const* const* envp) {
         vector<string> sourceFiles;
         if (!clayScript.empty()) {
             clayScriptSource = clayScriptImports + "main() {\n" + clayScript + "}";
-            m = loadProgramSource("-e", clayScriptSource, verbose);
+            m = loadProgramSource("-e", clayScriptSource, verbose, repl);
         } else if (generateDeps)
-            m = loadProgram(clayFile, &sourceFiles, verbose);
+            m = loadProgram(clayFile, &sourceFiles, verbose, repl);
         else
-            m = loadProgram(clayFile, NULL, verbose);
+            m = loadProgram(clayFile, NULL, verbose, repl);
 
         loadTimer.stop();
         compileTimer.start();

--- a/compiler/clay.hpp
+++ b/compiler/clay.hpp
@@ -2481,30 +2481,6 @@ struct MultiPValue : public Object {
 
 
 //
-// parser module
-//
-
-
-enum ParserFlags
-{
-    NoParserFlags = 0,
-    ParserKeepDocumentation = 1
-};
-
-ModulePtr parse(llvm::StringRef moduleName, SourcePtr source, ParserFlags flags = NoParserFlags);
-ExprPtr parseExpr(SourcePtr source, int offset, int length);
-ExprListPtr parseExprList(SourcePtr source, int offset, int length);
-void parseStatements(SourcePtr source, int offset, int length,
-    vector<StatementPtr> &statements);
-void parseTopLevelItems(SourcePtr source, int offset, int length,
-    vector<TopLevelItemPtr> &topLevels, Module *);
-void parseInteractive(SourcePtr source, int offset, int length,
-                      vector<TopLevelItemPtr>& toplevels,
-                      vector<ImportPtr>& imports,
-                      vector<StatementPtr>& stmts);
-
-
-//
 // printer module
 //
 

--- a/compiler/claydoc.cpp
+++ b/compiler/claydoc.cpp
@@ -1,4 +1,5 @@
 #include "claydoc.hpp"
+#include "parser.hpp"
 #include <sstream>
 #include <string>
 

--- a/compiler/codegen.cpp
+++ b/compiler/codegen.cpp
@@ -11,7 +11,7 @@
 #include "literals.hpp"
 #include "desugar.hpp"
 #include "constructors.hpp"
-
+#include "parser.hpp"
 
 
 #pragma clang diagnostic ignored "-Wcovered-switch-default"

--- a/compiler/desugar.cpp
+++ b/compiler/desugar.cpp
@@ -3,7 +3,7 @@
 #include "evaluator.hpp"
 #include "analyzer.hpp"
 #include "desugar.hpp"
-
+#include "parser.hpp"
 
 namespace clay {
 

--- a/compiler/interactive.cpp
+++ b/compiler/interactive.cpp
@@ -11,7 +11,7 @@
 
 namespace clay {
 
-    using std::ostringstream;
+    typedef llvm::SmallString<16U> Str;
 
     const char* replAnonymousFunctionName = "__replAnonymousFunction__";
 
@@ -21,6 +21,8 @@ namespace clay {
     jmp_buf recovery;
 
     static bool printAST = false;
+
+    static void eval(llvm::StringRef code);
 
     string newFunctionName()
     {
@@ -51,30 +53,75 @@ namespace clay {
         tokenize(source, 0, line.length(), tokens);
         return tokens;
     }
+  
+    static void cmdGlobals(const vector<Token>& tokens) {
+        ModulePtr m;
+        if (tokens.size() == 1) {
+            m = module;
+        } else if (tokens.size() == 2) {
+            m = globalModules[tokens[1].str];
+        } else {
+            llvm::errs() << ":globals [module name]\n";
+            return;
+        }
+
+        string buf;
+        llvm::raw_string_ostream code(buf);
+
+        llvm::StringMap<ObjectPtr>::const_iterator g = m->globals.begin();
+        for (; g != m->globals.end(); ++g) {
+            if (g->second->objKind == GLOBAL_VARIABLE) {
+                IdentifierPtr name = ((GlobalVariable*)g->second.ptr())->name;
+                code << "println(\"" << name->str << " : \", " 
+                                     << "Type(" << name->str << "), \" : \", "
+                                     << name->str <<");\n";
+            }
+        }
+        code.flush();
+        eval(buf);
+    }
+
+    static void cmdModules(const vector<Token>& tokens) {
+        if (tokens.size() != 1) {
+            llvm::errs() << "Warning: command parameters are ignored\n";
+        }
+        llvm::StringMap<ModulePtr>::const_iterator iter = globalModules.begin();
+        for (; iter != globalModules.end(); ++iter) {
+            llvm::errs() << iter->getKey() << "\n";
+        }
+    }
+
+    static void cmdPrint(const vector<Token>& tokens) {
+        for (size_t i = 1; i < tokens.size(); ++i) {
+            if (tokens[i].tokenKind == T_IDENTIFIER) {
+                Str identifier = tokens[i].str;
+                llvm::StringMap<ImportSet>::const_iterator iter = module->allSymbols.find(identifier);
+                if (iter == module->allSymbols.end()) {
+                    llvm::errs() << "Can't find identifier " << identifier.c_str();
+                } else {
+                    for (size_t i = 0; i < iter->second.size(); ++i) {
+                        llvm::errs() << iter->second[i] << "\n";
+                    }
+                }
+            }
+        }
+    }
 
     static void replCommand(string const& line)
     {
-        typedef llvm::SmallString<16U> Str;
         SourcePtr source = new Source(line, 0);
         vector<Token> tokens;
+        //TODO: don't use compiler's tokenizer
         tokenize(source, 0, line.length(), tokens);
         Str cmd = tokens[0].str;
         if (cmd == "q") {
             exit(0);
+        } else if (cmd == "globals") {
+            cmdGlobals(tokens);
+        } else if (cmd == "modules") {
+            cmdModules(tokens);
         } else if (cmd == "print") {
-            for (size_t i = 1; i < tokens.size(); ++i) {
-                if (tokens[i].tokenKind == T_IDENTIFIER) {
-                    Str identifier = tokens[i].str;
-                    llvm::StringMap<ImportSet>::const_iterator iter = module->allSymbols.find(identifier);
-                    if (iter == module->allSymbols.end()) {
-                        llvm::errs() << "Can't find identifier " << identifier.c_str();
-                    } else {
-                        for (size_t i = 0; i < iter->second.size(); ++i) {
-                            llvm::errs() << iter->second[i] << "\n";
-                        }
-                    }
-                }
-            }
+            cmdPrint(tokens);
         } else if (cmd == "ast_on") {
             printAST = true;
         } else if (cmd == "ast_off") {
@@ -168,6 +215,23 @@ namespace clay {
         jitStatements(vector<StatementPtr>(1, callStmt.ptr()));
     }
 
+    static void eval(llvm::StringRef line) {
+        SourcePtr source = new Source(line, 0);
+        try {
+            ReplItem x = parseInteractive(source, 0, source->size());
+            if (x.isExprSet) {
+                jitAndPrintExpr(x.expr);
+            } else {
+                loadImports(x.imports);
+                jitTopLevel(x.toplevels);
+                jitStatements(x.stmts);
+            }
+        }
+        catch (CompilerError) {
+            return;
+        }        
+    }
+
     static void interactiveLoop()
     {
         setjmp(recovery);
@@ -181,20 +245,7 @@ namespace clay {
             if (line[0] == ':') {
                 replCommand(line.substr(1, line.size() - 1));
             } else {
-                SourcePtr source = new Source(line, 0);
-                try {
-                    ReplItem x = parseInteractive(source, 0, source->size());
-                    if (x.isExprSet) {
-                        jitAndPrintExpr(x.expr);
-                    } else {
-                        loadImports(x.imports);
-                        jitTopLevel(x.toplevels);
-                        jitStatements(x.stmts);
-                    }
-                }
-                catch (CompilerError) {
-                    continue;
-                }
+                eval(line);
             }
         }
         engine->runStaticConstructorsDestructors(true);
@@ -217,6 +268,8 @@ namespace clay {
         llvm::errs() << "Clay interpreter\n";
         llvm::errs() << ":q to exit\n";
         llvm::errs() << ":print {identifier} to print an identifier\n";
+        llvm::errs() << ":modules to list global modules\n";
+        llvm::errs() << ":globals to list globals\n";
         llvm::errs() << "In multi-line mode empty line to exit\n";
 
         llvm::EngineBuilder eb(llvmModule);

--- a/compiler/interactive.cpp
+++ b/compiler/interactive.cpp
@@ -174,14 +174,11 @@ namespace clay {
                 replCommand(line.substr(1, line.size() - 1));
             } else {
                 SourcePtr source = new Source(line, 0);
-                vector<StatementPtr> stmts;
-                vector<TopLevelItemPtr> toplevels;
-                vector<ImportPtr> imports;
                 try {
-                    parseInteractive(source, 0, source->size(), toplevels, imports, stmts);
-                    loadImports(imports);
-                    jitTopLevel(toplevels);
-                    jitStatements(stmts);
+                    ReplItem x = parseInteractive(source, 0, source->size());
+                    loadImports(x.imports);
+                    jitTopLevel(x.toplevels);
+                    jitStatements(x.stmts);
                 }
                 catch (CompilerError) {
                     continue;

--- a/compiler/interactive.cpp
+++ b/compiler/interactive.cpp
@@ -1,5 +1,6 @@
 #include "clay.hpp"
 #include "lexer.hpp"
+#include "parser.hpp"
 #include "codegen.hpp"
 #include "error.hpp"
 #include "loader.hpp"
@@ -39,6 +40,16 @@ namespace clay {
                 break;
         }
         return s.substr(i, s.length());
+    }
+
+    static vector<Token> addTokens() {
+        char buf[255];
+        string line = fgets(buf, 255, stdin);
+        line = stripSpaces(line);
+        SourcePtr source = new Source(line, 0);
+        vector<Token> tokens;
+        tokenize(source, 0, line.length(), tokens);
+        return tokens;
     }
 
     static void replCommand(string const& line)
@@ -197,6 +208,7 @@ namespace clay {
         llvm::errs() << "Clay interpreter\n";
         llvm::errs() << ":q to exit\n";
         llvm::errs() << ":print {identifier} to print an identifier\n";
+        llvm::errs() << "In multi-line mode empty line to exit\n";
 
         llvm::EngineBuilder eb(llvmModule);
         llvm::TargetOptions targetOptions;
@@ -204,6 +216,8 @@ namespace clay {
         eb.setTargetOptions(targetOptions);
         engine = eb.create();
         engine->runStaticConstructorsDestructors(false);
+
+        setAddTokens(&addTokens);
 
         interactiveLoop();
     }

--- a/compiler/invoketables.cpp
+++ b/compiler/invoketables.cpp
@@ -171,6 +171,19 @@ InvokeSet* lookupInvokeSet(ObjectPtr callable,
     return invokeSet;
 }
 
+vector<InvokeSet*> lookupInvokeSets(ObjectPtr callable) {
+    assert(invokeTablesInitialized);
+    vector<InvokeSet*> r;
+    for (size_t i = 0; i < invokeTable.size(); ++i) {
+        for (size_t j = 0; j < invokeTable[i].size(); ++j) {
+            InvokeSet* set = invokeTable[i][j];
+            if (objectEquals(set->callable, callable)) {
+                r.push_back(set);
+            }
+        }
+    }
+    return r;
+}
 
 
 //

--- a/compiler/invoketables.hpp
+++ b/compiler/invoketables.hpp
@@ -105,6 +105,7 @@ struct MatchFailureError {
 
 InvokeSet *lookupInvokeSet(ObjectPtr callable,
                            llvm::ArrayRef<TypePtr> argsKey);
+vector<InvokeSet*> lookupInvokeSets(ObjectPtr callable);
 InvokeEntry* lookupInvokeEntry(ObjectPtr callable,
                                llvm::ArrayRef<TypePtr> argsKey,
                                llvm::ArrayRef<ValueTempness> argsTempness,

--- a/compiler/loader.cpp
+++ b/compiler/loader.cpp
@@ -396,15 +396,24 @@ static void loadDependents(ModulePtr m, vector<string> *sourceFiles, bool verbos
     }
 }
 
-static ModulePtr loadPrelude(vector<string> *sourceFiles, bool verbose) {
-    DottedNamePtr dottedName = new DottedName();
-    dottedName->parts.push_back(Identifier::get("prelude"));
-    return loadModuleByName(dottedName, sourceFiles, verbose);
+static ModulePtr loadPrelude(vector<string> *sourceFiles, bool verbose, bool repl) {
+    if (!repl) {
+        DottedNamePtr dottedName = new DottedName();
+        dottedName->parts.push_back(Identifier::get("prelude"));
+        return loadModuleByName(dottedName, sourceFiles, verbose);
+    } else {
+        DottedNamePtr dottedName = new DottedName();
+        dottedName->parts.push_back(Identifier::get("prelude"));
+        dottedName->parts.push_back(Identifier::get("repl"));
+        ModulePtr m = loadModuleByName(dottedName, sourceFiles, verbose);
+        globalModules["prelude"] = m;
+        return m;
+    }
 }
 
-ModulePtr loadProgram(llvm::StringRef fileName, vector<string> *sourceFiles, bool verbose) {
+ModulePtr loadProgram(llvm::StringRef fileName, vector<string> *sourceFiles, bool verbose, bool repl) {
     globalMainModule = parse("", loadFile(fileName, sourceFiles));
-    ModulePtr prelude = loadPrelude(sourceFiles, verbose);
+    ModulePtr prelude = loadPrelude(sourceFiles, verbose, repl);
     loadDependents(globalMainModule, sourceFiles, verbose);
     installGlobals(globalMainModule);
     initModule(prelude);
@@ -412,7 +421,7 @@ ModulePtr loadProgram(llvm::StringRef fileName, vector<string> *sourceFiles, boo
     return globalMainModule;
 }
 
-ModulePtr loadProgramSource(llvm::StringRef name, llvm::StringRef source, bool verbose) {
+ModulePtr loadProgramSource(llvm::StringRef name, llvm::StringRef source, bool verbose, bool repl) {
     SourcePtr mainSource = new Source(name,
         llvm::MemoryBuffer::getMemBufferCopy(source));
     if (llvmDIBuilder != NULL) {
@@ -423,7 +432,7 @@ ModulePtr loadProgramSource(llvm::StringRef name, llvm::StringRef source, bool v
 
     globalMainModule = parse("", mainSource);
     // Don't keep track of source files for -e script
-    ModulePtr prelude = loadPrelude(NULL, verbose);
+    ModulePtr prelude = loadPrelude(NULL, verbose, repl);
     loadDependents(globalMainModule, NULL, verbose);
     installGlobals(globalMainModule);
     initModule(prelude);

--- a/compiler/loader.cpp
+++ b/compiler/loader.cpp
@@ -5,7 +5,7 @@
 #include "codegen.hpp"
 #include "evaluator.hpp"
 #include "constructors.hpp"
-
+#include "parser.hpp"
 
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 

--- a/compiler/loader.hpp
+++ b/compiler/loader.hpp
@@ -16,8 +16,8 @@ void getProcedureMonoTypes(ProcedureMono &mono, EnvPtr env,
 
 void initLoader();
 void setSearchPath(const llvm::ArrayRef<PathString> path);
-ModulePtr loadProgram(llvm::StringRef fileName, vector<string> *sourceFiles, bool verbose);
-ModulePtr loadProgramSource(llvm::StringRef name, llvm::StringRef source, bool verbose);
+ModulePtr loadProgram(llvm::StringRef fileName, vector<string> *sourceFiles, bool verbose, bool repl);
+ModulePtr loadProgramSource(llvm::StringRef name, llvm::StringRef source, bool verbose, bool repl);
 ModulePtr loadedModule(llvm::StringRef module);
 ModulePtr preludeModule();
 ModulePtr primitivesModule();

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -9,7 +9,6 @@ map<llvm::StringRef, IdentifierPtr> Identifier::freeIdentifiers;
 static vector<Token> *tokens;
 static int position;
 static int maxPosition;
-static int sourceSize;
 static bool parserOptionKeepDocumentation = false;
 
 static AddTokensCallback addTokens = NULL;
@@ -3114,7 +3113,7 @@ static bool module(llvm::StringRef moduleName, ModulePtr &x) {
 static bool replItems(ReplItem& x, bool = false) {
     inRepl = false;
     int p = save();
-    if (expression(x.expr) && position == sourceSize) {
+    if (expression(x.expr) && position == tokens->size()) {
         x.isExprSet = true;
         return true;
     }
@@ -3173,7 +3172,6 @@ void applyParser(SourcePtr source, int offset, int length, Parser parser, Parser
 
     tokens = &t;
     position = maxPosition = 0;
-    sourceSize = t.size();
 
     if (!parser(node, parserParam) || (position < (int)t.size())) {
         Location location;

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -3110,13 +3110,7 @@ static bool module(llvm::StringRef moduleName, ModulePtr &x) {
 // REPL
 //
 
-struct REPLitem {
-    vector<TopLevelItemPtr> toplevels;
-    vector<ImportPtr> imports;
-    vector<StatementPtr> stmts;
-};
-
-static bool replItems(REPLitem& x, bool = false) {
+static bool replItems(ReplItem& x, bool = false) {
     x.toplevels.clear();
     x.imports.clear();
     x.stmts.clear();
@@ -3244,16 +3238,11 @@ void parseTopLevelItems(SourcePtr source, int offset, int length,
 // parseInteractive
 //
 
-void parseInteractive(SourcePtr source, int offset, int length,
-                      vector<TopLevelItemPtr>& toplevels,
-                      vector<ImportPtr>& imports,
-                      vector<StatementPtr>& stmts)
+ReplItem parseInteractive(SourcePtr source, int offset, int length)
 {
-    REPLitem x;
+    ReplItem x;
     applyParser(source, offset, length, replItems, false, x);
-    toplevels = x.toplevels;
-    imports = x.imports;
-    stmts = x.stmts;
+    return x;
 }
 
 }

--- a/compiler/parser.hpp
+++ b/compiler/parser.hpp
@@ -13,6 +13,8 @@ enum ParserFlags
 };
 
 struct ReplItem {
+    bool isExprSet;
+    ExprPtr expr;
     vector<TopLevelItemPtr> toplevels;
     vector<ImportPtr> imports;
     vector<StatementPtr> stmts;

--- a/compiler/parser.hpp
+++ b/compiler/parser.hpp
@@ -1,0 +1,32 @@
+#ifndef __PARSER_HPP
+#define __PARSER_HPP
+
+#include "clay.hpp"
+#include "lexer.hpp"
+
+namespace clay { 
+
+enum ParserFlags
+{
+    NoParserFlags = 0,
+    ParserKeepDocumentation = 1
+};
+
+ModulePtr parse(llvm::StringRef moduleName, SourcePtr source, ParserFlags flags = NoParserFlags);
+ExprPtr parseExpr(SourcePtr source, int offset, int length);
+ExprListPtr parseExprList(SourcePtr source, int offset, int length);
+void parseStatements(SourcePtr source, int offset, int length,
+    vector<StatementPtr> &statements);
+void parseTopLevelItems(SourcePtr source, int offset, int length,
+    vector<TopLevelItemPtr> &topLevels, Module *);
+void parseInteractive(SourcePtr source, int offset, int length,
+                      vector<TopLevelItemPtr>& toplevels,
+                      vector<ImportPtr>& imports,
+                      vector<StatementPtr>& stmts);
+
+typedef vector<Token>(*AddTokensCallback)();
+void setAddTokens(AddTokensCallback f);
+
+}
+
+#endif // __PARSER_HPP

--- a/compiler/parser.hpp
+++ b/compiler/parser.hpp
@@ -12,6 +12,12 @@ enum ParserFlags
     ParserKeepDocumentation = 1
 };
 
+struct ReplItem {
+    vector<TopLevelItemPtr> toplevels;
+    vector<ImportPtr> imports;
+    vector<StatementPtr> stmts;
+};
+
 ModulePtr parse(llvm::StringRef moduleName, SourcePtr source, ParserFlags flags = NoParserFlags);
 ExprPtr parseExpr(SourcePtr source, int offset, int length);
 ExprListPtr parseExprList(SourcePtr source, int offset, int length);
@@ -19,10 +25,7 @@ void parseStatements(SourcePtr source, int offset, int length,
     vector<StatementPtr> &statements);
 void parseTopLevelItems(SourcePtr source, int offset, int length,
     vector<TopLevelItemPtr> &topLevels, Module *);
-void parseInteractive(SourcePtr source, int offset, int length,
-                      vector<TopLevelItemPtr>& toplevels,
-                      vector<ImportPtr>& imports,
-                      vector<StatementPtr>& stmts);
+ReplItem parseInteractive(SourcePtr source, int offset, int length);
 
 typedef vector<Token>(*AddTokensCallback)();
 void setAddTokens(AddTokensCallback f);

--- a/lib-clay/prelude/repl/repl.clay
+++ b/lib-clay/prelude/repl/repl.clay
@@ -1,0 +1,2 @@
+public import prelude.*;
+public import printer.*;


### PR DESCRIPTION
`next` token function in parser runs a callback to get tokens from console if it is in repl

```
$clay -repl ../examples/factorial.clay
clay>[T]   
foo(z:T){
var x = 5;
var y = 6;
println(x * y * z);
}
clay>foo(1);
30
```

`Parser.hpp` extraction is for using `#include lexer.hpp` in the header.
