### PR TITLE
hide platform-specific members

### DIFF
--- a/lib-clay/io/paths/paths.unix.clay
+++ b/lib-clay/io/paths/paths.unix.clay
@@ -11,7 +11,7 @@ import data.sequences.*;
 
 /// @section  PATH_SEPARATOR, PATH_LIST_SEPARATOR, rootDirectory?, absolutePath? 
 
-alias PATH_SEPARATOR = '/';
+private alias PATH_SEPARATOR = '/';
 alias PATH_LIST_SEPARATOR = ':';
 
 rootDirectory?(s) = (s == "/");

--- a/lib-clay/io/paths/paths.windows.clay
+++ b/lib-clay/io/paths/paths.windows.clay
@@ -9,15 +9,15 @@ import data.sequences.*;
 
 /// @section  separators 
 
-alias PATH_SEPARATOR1 = '\\';
-alias PATH_SEPARATOR2 = '/';
+private alias PATH_SEPARATOR1 = '\\';
+private alias PATH_SEPARATOR2 = '/';
 
-alias DRIVE_SEPARATOR = ':';
+private alias DRIVE_SEPARATOR = ':';
 
 alias PATH_LIST_SEPARATOR = ';';
 
 pathSeparator?(c) = (c == PATH_SEPARATOR1) or (c == PATH_SEPARATOR2);
-pathOrDriveSeparator?(c) = pathSeparator?(c) or (c == DRIVE_SEPARATOR);
+private pathOrDriveSeparator?(c) = pathSeparator?(c) or (c == DRIVE_SEPARATOR);
 
 private beginsWithPathSeparator?(s) = (not empty?(s)) and pathSeparator?(front(s));
 private endsWithPathSeparator?(s) = (not empty?(s)) and pathSeparator?(back(s));


### PR DESCRIPTION
I think that platform-specific members of module should be either hidden (as done in this patch) or renamed to something like WINDOWS_PATH_SEPARATOR1 and UNIX_PATH_SEPARATOR and made available on all platforms.
