### PR TITLE
pass optimization level to TargetMachine correctly

### DIFF
--- a/compiler/codegen.hpp
+++ b/compiler/codegen.hpp
@@ -21,7 +21,7 @@ llvm::TargetMachine *initLLVM(llvm::StringRef targetTriple,
     llvm::StringRef flags,
     bool relocPic,
     bool debug,
-    bool optimized);
+    unsigned optLevel);
 
 bool inlineEnabled();
 void setInlineEnabled(bool enabled);


### PR DESCRIPTION
Now there is no optimization level for `TargetMachine::addPassesToEmitFile`.
This patch moves the level to `Target::createTargetMachine`.
