### PR TITLE
disable int bit-mask fields

### DIFF
--- a/compiler/clay.hpp
+++ b/compiler/clay.hpp
@@ -2392,8 +2392,8 @@ struct Module : public ANode {
 
     set<string> importedNames;
 
-    int publicSymbolsLoading:3;
-    int allSymbolsLoading:3;
+    int publicSymbolsLoading; //:3;
+    int allSymbolsLoading; //:3;
     bool attributesVerified:1;
     bool publicSymbolsLoaded:1;
     bool allSymbolsLoaded:1;

--- a/compiler/codegen.hpp
+++ b/compiler/codegen.hpp
@@ -137,7 +137,7 @@ struct CodegenContext {
     vector<JumpTarget> continues;
     vector<JumpTarget> exceptionTargets;
     llvm::Value *exceptionValue;
-    int inlineDepth:31;
+    int inlineDepth; //:31;
     bool checkExceptions:1;
 
     CodegenContext()

--- a/compiler/invoketables.hpp
+++ b/compiler/invoketables.hpp
@@ -85,7 +85,7 @@ struct InvokeSet {
     map<vector<ValueTempness>, InvokeEntry*> tempnessMap;
     map<vector<ValueTempness>, InvokeEntry*> tempnessMap2;
 
-    unsigned nextOverloadIndex:31;
+    unsigned nextOverloadIndex; //:31;
 
     bool shouldLog:1;
 


### PR DESCRIPTION
This is work around clang/llvm 3.2 bug:
http://llvm.org/bugs/show_bug.cgi?id=14880
