### PR TITLE
drop Function, rename FunctionBody -> Function

### DIFF
--- a/lib-clay/lambdas/lambdas.clay
+++ b/lib-clay/lambdas/lambdas.clay
@@ -1,30 +1,64 @@
-
-import sharedpointers.*;
+// main constructor
 
 
-/// @section  Function - polymorphic callable object container 
+/// @section  Function 
 
-record Function[In,Out] (
-    body : SharedPointer[FunctionBody[In,Out]]
+record Function[In, Out] (
+    obj : Pointer[Opaque],
+    code : CodePointer[[Opaque, ..unpack(In)], Out],
+    destructor : CodePointer[[Opaque],[]],
 );
 
+[..I, ..O]
+overload RegularRecord?(#Function[[..I], [..O]]) = false;
 
-// main constructor
+[..I, ..O]
+overload BitwiseMovedType?(#Function[[..I], [..O]]) = true;
+
+private define Function?(T) : Bool;
+overload Function?(T) = false;
+[..I, ..O]
+overload Function?(#Function[[..I], [..O]]) = true;
+
+[..I, ..O]
+overload call(x:Function[[..I], [..O]], forward ..args:I) : ..O {
+    return forward ..x.code(x.obj^, ..args);
+}
+
+[..I, ..O]
+overload Function[[..I], [..O]]() --> returned:Function[[..I], [..O]] {
+    returned.obj <-- Type(returned.obj)();
+    returned.code <-- Type(returned.code)();
+    returned.destructor <-- Type(returned.destructor)();
+}
 
 /* this comes before Function[In, Out] so that the shim isn't constructed if the object
    natively returns no values */
-[..In, T when CallDefined?(call, T, ..In)]
-alias overload Function[[..In], []](x:T) {
-    return Function[[..In],[]](new(FunctionBody[[..In],[]]((forward ..args) => { x(..args); })));
+[..In, T when CallDefined?(call, T, ..In) and not Function?(T)]
+overload Function[[..In], []](x:T) {
+    return Function[[..In],[]]((forward ..args) => { x(..args); });
 }
 
-[In, Out, T when CallableWithSignature?(T, In, Out)]
-alias overload Function[In, Out](x:T) {
-    return Function[In,Out](new(FunctionBody[In,Out](x)));
+[..I, ..O, T when CallDefined?(call, T, ..I) and not Function?(T)]
+overload Function[[..I],[..O]](x:T) --> returned:Function[[..I],[..O]] {
+    var codePtr = makeCodePointer(call, T, ..I);
+    var destructor = makeCodePointer(destroy, T);
+    returned.code = CodePointer[[Opaque, ..I], [..O]](codePtr);
+    returned.destructor = CodePointer[[Opaque],[]](destructor);
+
+    var ptr = allocateRawMemoryAligned(T, 1, TypeAlignment(T));
+    try {
+        ptr^ <-- x;
+    }
+    catch (e) {
+        freeRawMemoryAligned(ptr);
+        throw e;
+    }
+    returned.obj = Pointer[Opaque](ptr);
 }
 
-[T when MonoType?(T)]
-alias overload Function(x:T) {
+[T when MonoType?(T) and not Function?(T)]
+overload Function(x:T) {
     return Function[[..MonoInputTypes(x)],[..MonoOutputTypes(x)]](x);
 }
 
@@ -42,18 +76,21 @@ overload CallableWithSignature?(#T, In:I, Out:O) {
 [In,..Out]
 private CodePointerReturnTypes(#CodePointer[In,[..Out]]) = [..Out];
 
-
-// redefine constructors shadowed by the primary constructor
-
-[In,Out]
-alias overload Function[In,Out](body : SharedPointer[FunctionBody[In,Out]]) --> returned:Function[In,Out] {
-    returned.body <-- body;
+[In, Out]
+overload resetUnsafe(x:Function[In, Out]) {
+    x <-- Function[In, Out]();
 }
 
-[In,Out]
-overload Function[In,Out](x : Function[In,Out]) --> returned:Function[In,Out] {
-    returned.body <-- x.body;
+[In, Out]
+overload destroy(x:Function[In, Out]) {
+    if (not null?(x.obj)) {
+        x.destructor(x.obj^);
+        freeRawMemoryAligned(x.obj);
+    }
 }
+
+staticassert(     Movable?(Type(Function(() -> {}))));
+staticassert(not Copyable?(Type(Function(() -> {}))));
 
 
 // makeFunction
@@ -69,48 +106,5 @@ makeFunction(forward x:T, ..In) {
 // call operator
 
 [..I, ..O]
-overload call(x:Function[[..I], [..O]], forward ..args:I) : ..O {
-    return forward call(x.body^, ..args);
-}
-
-[..I, ..O]
 alias overload MonoInputTypes(x:Function[[..I], [..O]]) = ..I;
-
-
-/// @section  FunctionBody 
-
-record FunctionBody[In, Out] (
-    obj : Pointer[Opaque],
-    code : CodePointer[[Opaque, ..unpack(In)], Out],
-    destructor : CodePointer[[Opaque],[]],
-);
-
-[..I, ..O]
-overload call(x:FunctionBody[[..I], [..O]], forward ..args:I) : ..O {
-    return forward ..x.code(x.obj^, ..args);
-}
-
-[..I, ..O, T]
-alias overload FunctionBody[[..I],[..O]](x:T) --> returned:FunctionBody[[..I],[..O]] {
-    var codePtr = makeCodePointer(call, T, ..I);
-    var destructor = makeCodePointer(destroy, T);
-    returned.code = CodePointer[[Opaque, ..I], [..O]](codePtr);
-    returned.destructor = CodePointer[[Opaque],[]](destructor);
-
-    var ptr = allocateRawMemoryAligned(T, 1, TypeAlignment(T));
-    try {
-        ptr^ <-- x;
-    }
-    catch (e) {
-        freeRawMemoryAligned(ptr);
-        throw e;
-    }
-    returned.obj = Pointer[Opaque](ptr);
-}
-
-[In, Out]
-overload destroy(x:FunctionBody[In, Out]) {
-    x.destructor(x.obj^);
-    freeRawMemoryAligned(x.obj);
-}
 

--- a/lib-clay/test/test.clay
+++ b/lib-clay/test/test.clay
@@ -26,9 +26,16 @@ record TestCase (
     xfail?: Bool,
 );
 
-[T, F when String?(T) and CallDefined?(call, F) and (T != String or F != TestFunction)]
+staticassert (     Movable?(TestCase));
+staticassert (not Copyable?(TestCase));
+
+[T, F when String?(T) and CallDefined?(call, F)]
 overload TestCase(name:T, _case:F, xfail?)
-    = TestCase(String(name), TestFunction(_case), xfail?);
+    = initializeRecord(TestCase, String(name), TestFunction(_case), xfail?);
+
+[T when String?(T)]
+overload TestCase(name:T, rvalue _case:TestFunction, xfail?)
+    = initializeRecord(TestCase, String(name), move(_case), xfail?);
 
 overload TestCase(name, fn) = TestCase(name, TestFunction(fn), false);
 
@@ -40,7 +47,8 @@ record TestSuite (
 );
 
 [S, T when S != String or T != Vector[TestCase]]
-overload TestSuite(name : S, testCases : T) = TestSuite(String(name), Vector[TestCase](testCases));
+overload TestSuite(name : S, rvalue testCases : T) =
+    TestSuite(String(name), Vector[TestCase](move(testCases)));
 
 alias TEST_CASE_INDENT = "  ";
 alias TEST_FAILURE_INDENT = TEST_CASE_INDENT++TEST_CASE_INDENT;

--- a/lib-clay/threads/core/core.clay
+++ b/lib-clay/threads/core/core.clay
@@ -20,7 +20,7 @@ startThread(proc): Thread {
             abort();
         }
     };
-    return Thread(startThreadImpl(allocateObject(FunctionBody[[], []](launcher))), false);
+    return Thread(startThreadImpl(allocateObject(Function[[], []](launcher))), false);
 }
 
 joinThread(thread: Thread) {

--- a/lib-clay/threads/core/platform/platform.unix.clay
+++ b/lib-clay/threads/core/platform/platform.unix.clay
@@ -5,13 +5,13 @@ import lambdas.*;
 alias ThreadHandle = pthread_t;
 
 private threadProc(param: RawPointer): RawPointer {
-    ref proc = bitcast(Pointer[FunctionBody[[], []]], param);
+    ref proc = bitcast(Pointer[Function[[], []]], param);
     finally freeObject(proc);
     proc^();
     return RawPointer();
 }
 
-startThreadImpl(proc: Pointer[FunctionBody[[], []]]) {
+startThreadImpl(proc: Pointer[Function[[], []]]) {
     var thread = pthread_t();
     var ok = pthread_create(@thread, null(pthread_attr_t), CCodePointer(threadProc), bitcast(RawPointer, proc));
     if (ok != 0) {

--- a/lib-clay/threads/core/platform/platform.windows.clay
+++ b/lib-clay/threads/core/platform/platform.windows.clay
@@ -5,13 +5,13 @@ import lambdas.*;
 alias ThreadHandle = HANDLE;
 
 private threadProc(param: RawPointer): DWORD {
-    ref proc = bitcast(Pointer[FunctionBody[[], []]], param);
+    ref proc = bitcast(Pointer[Function[[], []]], param);
     finally freeObject(proc);
     proc^();
     return DWORD();
 }
 
-startThreadImpl(proc: Pointer[FunctionBody[[], []]]) {
+startThreadImpl(proc: Pointer[Function[[], []]]) {
     var thread = CreateThread(LPSECURITY_ATTRIBUTES(), SIZE_T(0), StdCallCodePointer(threadProc), bitcast(LPVOID, proc), DWORD(0), LPDWORD());
     if (null?(thread)) {
         freeObject(proc);


### PR DESCRIPTION
If someone needs Function to be refcounted, Function can be explicitly
wrapped in sharedpointer, like this:

```
var functionPtr = new(Function((x: Int) -> x * 2));
var thirtyFour = functionPtr^(17);
```

Note that sharedpointers are not thread-safe (thus Function weren't
thread-safe until this patch), so simple function copying could
cause memory problems.
