### PR TITLE
UniString? and related changes

### DIFF
--- a/lib-clay/core/strings/strings.clay
+++ b/lib-clay/core/strings/strings.clay
@@ -9,6 +9,9 @@
 [A]
 String?(#A) = Sequence?(A) and SequenceElementType(A) == Char;
 
+[A]
+UniString?(#A) = Sequence?(A) and SequenceElementType(A) == UniChar;
+
 
 
 /// @section  SizedString? 
@@ -16,12 +19,18 @@ String?(#A) = Sequence?(A) and SequenceElementType(A) == Char;
 [A]
 SizedString?(#A) = String?(A) and SizedSequence?(A);
 
+[A]
+SizedUniString?(A) = UniString?(A) and SizedSequence?(A);
+
 
 
 /// @section  ContiguousString? 
 
 [A]
 ContiguousString?(#A) = String?(A) and ContiguousSequence?(A);
+
+[A]
+ContiguousUniString?(#A) = UniString?(A) and ContiguousSequence?(A);
 
 
 

--- a/lib-clay/core/strings/strings.clay
+++ b/lib-clay/core/strings/strings.clay
@@ -6,40 +6,22 @@
 
 /// @section  String? 
 
-[T]
-define String?(#T) : Bool;
-
 [A]
-overload String?(#A) : Bool = false;
-
-[A when Sequence?(A) and (Char == SequenceElementType(A))]
-overload String?(#A) : Bool = true;
+String?(#A) = Sequence?(A) and SequenceElementType(A) == Char;
 
 
 
 /// @section  SizedString? 
 
 [A]
-define SizedString?(#A) : Bool;
-
-[A]
-overload SizedString?(#A) : Bool = false;
-
-[A when SizedSequence?(A) and (Char == SequenceElementType(A))]
-overload SizedString?(#A) : Bool = true;
+SizedString?(#A) = String?(A) and SizedSequence?(A);
 
 
 
 /// @section  ContiguousString? 
 
 [A]
-define ContiguousString?(#A) : Bool;
-
-[A]
-overload ContiguousString?(#A) : Bool = false;
-
-[A when ContiguousSequence?(A) and (Char == SequenceElementType(A))]
-overload ContiguousString?(#A) : Bool = true;
+ContiguousString?(#A) = String?(A) and ContiguousSequence?(A);
 
 
 

--- a/lib-clay/data/strings/encodings/utf8/utf8.clay
+++ b/lib-clay/data/strings/encodings/utf8/utf8.clay
@@ -1,4 +1,5 @@
 import printer.protocol.(printTo);
+import data.strings.(String);
 
 record UTF8Decoder[Iterator] (
     iter: Iterator
@@ -100,6 +101,8 @@ record UTF8[Sequence] (
 );
 
 [T] overload iterator(u: UTF8[T]) = UTF8Decoder(iterator(u.encoded));
+
+staticassert(UniString?(UTF8[String]));
 
 private encodeTwo(code)
     = bitor(0xC0, bitshr(bitand(code, 0x7C0), 6)),

--- a/lib-clay/printer/types/types.clay
+++ b/lib-clay/printer/types/types.clay
@@ -235,10 +235,10 @@ overload printTo(stream, x:UniChar) {
     encodeUniChar(x, c -> ..printTo(stream, c));
 }
 
-[S when String?(S)]
+[S when String?(S) or UniString?(S)]
 overload printTo(stream, x:S) {
     for (c in x)
-        write(stream, c);
+        printTo(stream, c);
 }
 
 [S when ContiguousString?(S)]

--- a/test/lib-clay/printing/1/test.clay
+++ b/test/lib-clay/printing/1/test.clay
@@ -43,5 +43,9 @@ main() = testMain(
             expectPrinted("aaa", CStringRef(cstring("aaa")));
             expectPrinted("(null)", CStringRef());
         }),
+        TestCase("UniString?", -> {
+            var s = array(UniChar('a'), UniChar('b'));
+            expectPrinted("ab", s);
+        }),
     )));
 


### PR DESCRIPTION
Pull request contains three commits:
- simplification of `String?` protocols (it is no longer overloadable, string is a `Sequence?` of `Char` and nothing more). A lot of code assumes that `String?` is a sequence (has `iterator`)
- addition of `UniString?` protocol. `UniString?` is like `String?`, but over `UniChar`
- overload `printTo` for `UniString?`: sequence of `UniChar` is printed encoded as UTF-8 now, instead of comma-separated sequence of characters
