### PR TITLE
Sequence construction API refactoring using elements function

### DIFF
--- a/lib-clay/commandline/options/parser.clay
+++ b/lib-clay/commandline/options/parser.clay
@@ -4,6 +4,7 @@ import data.strings.*;
 import data.vectors.*;
 import data.sequences.*;
 import data.sequences.operators.*;
+import printer.(str);
 
 record OptionValue(
   option : String,
@@ -63,12 +64,12 @@ parseOptions(ops : OptionSpecs, args) : ParseResult {
             // but return the same results from splitOption
             if(shortOption?(token)){
               for(c in slicedFrom(token, 1)){
-                var spec? = lookup(ops, String(c));
+                var spec? = lookup(ops, string(c));
 
                 if(variantIs?(spec?, Nothing)){
                   unrecognisedOption(pr, c);
                 } else {
-                  addOption(pr, String(c));
+                  addOption(pr, string(c));
                 }
               }
             } else {
@@ -93,9 +94,9 @@ private splitOption(token){
   if(argument?(token)) errorWithPrintf("Invalid argument: splitOption called on non-option");
 
   if(shortOption?(token)){
-    if(size(token) == 2) return ..String(token[1]), nothing(String);
+    if(size(token) == 2) return ..string(token[1]), nothing(String);
     else {
-      return ..String(token[1]), Maybe(sliceFrom(token, 2));
+      return ..string(token[1]), Maybe(sliceFrom(token, 2));
     }
   }
 
@@ -160,7 +161,7 @@ addSeparator(pr){
 }
 
 private unrecognisedOption(pr, op){
-  addError(pr, "Unrecognised option " ++ String(op));
+  addError(pr, "Unrecognised option " ++ str(op));
 }
 
 private unexpectedValue(pr, spec, value){

--- a/lib-clay/commandline/options/spec.clay
+++ b/lib-clay/commandline/options/spec.clay
@@ -41,8 +41,13 @@ private SpecPart?(#T) = String?(T) or (T == Char) or (T == Flags);
 
 private define addSpecPart;
 
-[T when String?(T) or (T == Char)] overload addSpecPart(spec, t : T){
-  push(spec.names, String(t)); 
+[T when String?(T)]
+overload addSpecPart(spec, t : T){
+  push(spec.names, String(t));
+}
+
+overload addSpecPart(spec, t : Char){
+  push(spec.names, string(t));
 }
 
 overload addSpecPart(spec, f : Flags){

--- a/lib-clay/data/deques/deques.clay
+++ b/lib-clay/data/deques/deques.clay
@@ -1,5 +1,6 @@
 import data.sequences.handle.*;
 import data.sequences.*;
+import data.elements.*;
 
 
 /// @section  Deque coordinates 
@@ -150,8 +151,11 @@ overload Deque[T](forward from: A) --> to: Deque[T] {
     }
 }
 
-[T, ..A when countValues(..A) > 0 and equalValues?(T, ..A)]
-overload Deque[T](forward ..from: A) --> to: Deque[T] {
+[T]
+overload Deque[T](elements: NoElements) = Deque[T]();
+
+[..A when equalValues?(..A)]
+deque(forward ..from: A) --> to: Deque[nthValue(#0, ..A)] {
     initializeDequeMap(to, SizeT(countValues(..A)));
 
     var i = to.begin;

--- a/lib-clay/data/elements/elements.clay
+++ b/lib-clay/data/elements/elements.clay
@@ -1,0 +1,10 @@
+define elements(..args) private overload;
+
+
+record NoElements ();
+
+overload elements() = NoElements();
+
+
+[..A when countValues(..A) > 0 and equalValues?(..A)]
+overload elements(..args: A) = array(..args);

--- a/lib-clay/data/queues/queues.clay
+++ b/lib-clay/data/queues/queues.clay
@@ -1,9 +1,13 @@
 import data.algorithms.heaps.*;
 import data.vectors.*;
+import data.elements.*;
 
 record Queue[S] (seq: S);
 
 alias VectorQueue[T] = Queue[Vector[T]];
+
+[..A when equalValues?(..A)]
+vectorQueue(..args: A) = VectorQueue[nthValue(#0, ..A)](..args);
 
 [S] overload Queue[S]() = Queue(S());
 
@@ -39,6 +43,9 @@ overload Queue[S](forward ..values: A) --> returned: Queue[S] {
         throw ex;
     }
 }
+
+[S]
+overload Queue[S](elements: NoElements) = Queue[S]();
 
 [S] queueEmpty?(q: Queue[S]) = empty?(q.seq);
 [S] queueSize(q: Queue[S]) = size(q.seq);

--- a/lib-clay/data/strings/strings.clay
+++ b/lib-clay/data/strings/strings.clay
@@ -7,6 +7,8 @@ import data.sequences.lazy.mapped.*;
 
 alias String = Vector[Char];
 
+string(..chars) = String(array(..chars));
+
 
 
 /// @section  construct from sequences of bytes 

--- a/lib-clay/data/vectors/vectors.clay
+++ b/lib-clay/data/vectors/vectors.clay
@@ -1,6 +1,7 @@
 
 import data.vectors.generic.*;
 public import data.vectors.generic.(Vector?);
+import data.elements.*;
 
 /// @module vector
 /// vector implementation
@@ -55,9 +56,16 @@ overload Vector(forward a:A) {
 
 /// @section varargs constructor
 
-[T, ..A when (countValues(..A) > 0) and equalValues?(T, ..A)]
-alias overload Vector[T](..elements:A) {
-    var v = Vector[T]();
+[A]
+alias overload Vector[A](elements: NoElements) = Vector[A]();
+
+/// Note this constructor cannot build vector from empty list of arguments
+/// because it cannot infer vector element type. If vector can be empty,
+/// and vector type is known, constructor from elements can be used:
+/// Vector[T](elements(..args))
+[..A when equalValues?(..A)]
+alias vector(..elements:A) {
+    var v = Vector[nthValue(#0, ..A)]();
     push(v, ..elements);
     return move(v);
 }

--- a/lib-clay/test/test.clay
+++ b/lib-clay/test/test.clay
@@ -7,6 +7,7 @@ import
     data.strings.*,
     lambdas.*,
     data.vectors.*,
+    data.elements.*,
     printer.formatter.(repr);
 
 
@@ -239,7 +240,7 @@ alias expectCallUndefined(Proc, ..Types) {
 
 [I]
 private expectIterator2(name, iter:I, ..expected) {
-    var expectedV = Vector[IteratorTargetType(I)](..expected);
+    var expectedV = Vector[IteratorTargetType(I)](elements(..expected));
     var resultV = Vector[IteratorTargetType(I)]();
     pushAll(resultV, iter);
     var msg = str("`", name, "` is expected to contain:\n");

--- a/test/lang/codepointers/1/main.clay
+++ b/test/lang/codepointers/1/main.clay
@@ -11,7 +11,7 @@ makeCPType(Inputs, Outputs) {
 }
 
 main() {
-    var a = Vector[Int](1, 2, 3, 4, 5);
+    var a = vector(1, 2, 3, 4, 5);
 
     showCPType( index, Type(a), Int );
     showCPType( clear, Type(a) );

--- a/test/lang/exceptions/vectors/main.clay
+++ b/test/lang/exceptions/vectors/main.clay
@@ -58,7 +58,7 @@ overload assign(dest:Test, src:Test) {
 
 main() {
     try {
-        var a = Vector[Test](Test(), Test(), Test(), Test());
+        var a = vector(Test(), Test(), Test(), Test());
         var b = Vector[Test]();
         b = move(a);
         var c = b;

--- a/test/lang/uncategorized/11/main.clay
+++ b/test/lang/uncategorized/11/main.clay
@@ -17,7 +17,7 @@ map(f, a) {
 }
 
 main() {
-    var a = Vector[Int](1, 2, 3);
+    var a = vector(1, 2, 3);
     var b = map(Multiplier(10), a);
     for (x in b)
         println(x);

--- a/test/lang/uncategorized/12/main.clay
+++ b/test/lang/uncategorized/12/main.clay
@@ -10,7 +10,7 @@ map(f, a) {
 }
 
 main() {
-    var a = Vector[Int](1, 2, 3, 4, 5, 6);
+    var a = vector(1, 2, 3, 4, 5, 6);
 
     var f = (x => x*10);
     var b = map(f, a);

--- a/test/lang/uncategorized/13/main.clay
+++ b/test/lang/uncategorized/13/main.clay
@@ -15,7 +15,7 @@ scale(factor, a) {
 }
 
 main() {
-    var a = Vector[Int](1, 2, 3, 4, 5, 6);
+    var a = vector(1, 2, 3, 4, 5, 6);
 
     for (x in a)
         println(x);

--- a/test/lang/uncategorized/14/main.clay
+++ b/test/lang/uncategorized/14/main.clay
@@ -28,7 +28,7 @@ testReturnByRef() {
 }
 
 main() {
-    var a = Vector[Int](1, 2, 3, 4, 5, 6);
+    var a = vector(1, 2, 3, 4, 5, 6);
     sumWithLambda(a);
     sumWithBlock(a);
     testReturnByRef();

--- a/test/lang/uncategorized/15/main.clay
+++ b/test/lang/uncategorized/15/main.clay
@@ -20,7 +20,7 @@ pack(f, a) = [f, a];
 main() {
     var V = Vector;
     var VI = V[Int32];
-    var a = VI(1, 2, 3, 4, 5, 6);
+    var a = VI(vector(1, 2, 3, 4, 5, 6));
 
     var pl = println;
 

--- a/test/lang/uncategorized/9/main.clay
+++ b/test/lang/uncategorized/9/main.clay
@@ -2,7 +2,7 @@ import printer.(println);
 import data.vectors.*;
 
 main() {
-    var v = Vector[Int](1, 2, 3, 4, 5);
+    var v = vector(1, 2, 3, 4, 5);
     var sum = 0;
     for (x in v)
         sum +: x;

--- a/test/lang/valuesemantics/main.clay
+++ b/test/lang/valuesemantics/main.clay
@@ -46,7 +46,7 @@ overload assign(dest:Test, src:Test) {
 }
 
 main() {
-    var a = Vector[Test](Test(), Test());
+    var a = vector(Test(), Test());
     reserve(a, 100);
     pushAll(a, array(Test(), Test(), Test(), Test(), Test()));
     var x = Test();

--- a/test/lib-clay/algorithms/count/main.clay
+++ b/test/lib-clay/algorithms/count/main.clay
@@ -3,7 +3,7 @@ import printer.(println);
 import data.vectors.*;
 
 main() {
-    var v = Vector[Int](1, 2, 3, 4, 5);
+    var v = vector(1, 2, 3, 4, 5);
     println(count(a => a % 2 == 0, v));
     println(count(a => a % 2 == 1, v));
 }

--- a/test/lib-clay/commandline/options/test.clay
+++ b/test/lib-clay/commandline/options/test.clay
@@ -3,6 +3,7 @@ import commandline.options.table.*;
 import commandline.options.parser.*;
 import data.strings.*;
 import data.vectors.*;
+import data.elements.*;
 
 fbbSpec() = OptionSpecs(array(
   OptionSpec('f', "foo"),
@@ -26,7 +27,7 @@ numberOfOptions(it) = numberOf(it, OptionValue);
 numberOfArguments(it) = numberOf(it, Argument);
 validOptions?(it) = numberOf(it, Error) == 0;
 
-PR(..args) = ParseResult(..mapValues(ParseToken, ..args));
+PR(..args) = ParseResult(elements(..mapValues(ParseToken, ..args)));
 
 main() = testMain(
   TestSuite("Raw option parsing", array(
@@ -34,7 +35,7 @@ main() = testMain(
       var opts = array("foo", "bar", "baz");
       for(opt in opts){
         var pr = parseOptions(fbbSpec(), array("--"++opt));
-        expectEqual(pr, Vector[ParseToken](ParseToken(OptionValue(opt))));
+        expectEqual(pr, vector(ParseToken(OptionValue(opt))));
       }
     }),
     TestCase("repeated options", -> {
@@ -50,7 +51,7 @@ main() = testMain(
     }),
     TestCase("with values as separate tokens", -> {
       var pr = parseOptions(valuableSpec(), array("--foo", "bar"));
-      expectEqual(ParseResult(ParseToken(OptionValue("foo", "bar"))), pr);
+      expectEqual(ParseResult(elements(ParseToken(OptionValue("foo", "bar")))), pr);
     }),
     TestCase("with values included in a short options", -> {
       var pr = parseOptions(valuableSpec(), array("-fbar"));
@@ -82,8 +83,8 @@ main() = testMain(
     TestCase("getting values", -> {
       var ot = OptionTable(valuableSpec(), array("-fkittens", "--bar=badgers", "--foo", "bunnies"));
 
-      expectEqual(getOptions(ot, "foo"), Vector[String](String("kittens"), String("bunnies")));
-      expectEqual(getOptions(ot, "bar"), Vector[String](String("badgers")));
+      expectEqual(getOptions(ot, "foo"), vector(String("kittens"), String("bunnies")));
+      expectEqual(getOptions(ot, "bar"), vector(String("badgers")));
     })
   ))
 );

--- a/test/lib-clay/core/memory/copy/main.clay
+++ b/test/lib-clay/core/memory/copy/main.clay
@@ -10,13 +10,13 @@ overload destroy(x: NonPODInt) {}
 
 main() {
     alias NP = NonPODInt;
-    var v1 = Vector[NP](NP(0), NP(1), NP(2), NP(3), NP(4), NP(5), NP(6), NP(7));
+    var v1 = vector(NP(0), NP(1), NP(2), NP(3), NP(4), NP(5), NP(6), NP(7));
     moveMemory(begin(v1), begin(v1) + 1, begin(v1) + 8);
     println("after moveMemory up:");
     for (x in v1)
         println(x);
 
-    var v2 = Vector[NP](NP(0), NP(1), NP(2), NP(3), NP(4), NP(5), NP(6), NP(7));
+    var v2 = vector(NP(0), NP(1), NP(2), NP(3), NP(4), NP(5), NP(6), NP(7));
     moveMemory(begin(v2) + 1, begin(v2), begin(v2)+7);
     println("after moveMemory down:");
     for (x in v2)

--- a/test/lib-clay/core/values/1/test.clay
+++ b/test/lib-clay/core/values/1/test.clay
@@ -1,6 +1,6 @@
 import printer.(str);
 import data.strings.(String);
-import data.vectors.(Vector);
+import data.vectors.*;
 import test.*;
 
 even?(x) = x % 2 == 0;
@@ -37,7 +37,7 @@ main() = testMain(
         TestCase("eachValue", -> {
             var r = Vector[String]();
             eachValue(x -> { push(r, str(x)); }, 1, 2.0, "three");
-            var expected = Vector[String](String("1"), String("2"), String("three"));
+            var expected = vector(String("1"), String("2"), String("three"));
             expectEqual(expected, r);
         }),
         TestCase("eachValue2", -> {
@@ -47,7 +47,7 @@ main() = testMain(
                 1, 2, 3,
                 7, 8, 9,
             );
-            var expected = Vector[Int](8, 10, 12);
+            var expected = vector(8, 10, 12);
             expectEqual(expected, r);
         }),
         TestCase("weaveValues", -> {

--- a/test/lib-clay/data/deques/main.clay
+++ b/test/lib-clay/data/deques/main.clay
@@ -86,7 +86,7 @@ main() {
     println();
     println("d2:");
 
-    var d2 = Deque[Int](2, 3, 5, 7, 11, 13);
+    var d2 = deque(2, 3, 5, 7, 11, 13);
     println("Size ", size(d2));
     print("Contents: ");
     for (x in d2) print(x, " ");
@@ -113,7 +113,7 @@ main() {
     println();
     println("d3:");
 
-    var v3 = Vector[Int](17, 19, 23, 29, 31, 37, 41);
+    var v3 = vector(17, 19, 23, 29, 31, 37, 41);
     var d3 = Deque[Int](v3);
     println("Size ", size(d3));
     print("Contents: ");
@@ -138,7 +138,7 @@ main() {
     for (x in d3) print(x, " ");
     println();
 
-    d3 = Deque[Int](1, 1, 2);
+    d3 = deque(1, 1, 2);
     println("Assigned from shorter rvalue size ", size(d3));
     print("Contents: ");
     for (x in d3) print(x, " ");
@@ -155,7 +155,7 @@ main() {
 
     println();
     println("d5:");
-    var v5 = Vector[Int](17, 19, 23, 29, 31, 37, 41);
+    var v5 = vector(17, 19, 23, 29, 31, 37, 41);
     var d5 = Deque[Int](filtered(x => x > 20, v5));
     println("Size ", size(d5));
     print("Contents: ");
@@ -233,7 +233,7 @@ main() {
     println();
 
     println("d7:");
-    var d7 = Deque[Int](10, 20, 30);
+    var d7 = deque(10, 20, 30);
     println("Size ", size(d7));
     print("Contents: ");
     for (x in d7) print(x, " ");

--- a/test/lib-clay/data/deques/memory/main.clay
+++ b/test/lib-clay/data/deques/memory/main.clay
@@ -7,7 +7,7 @@ overload DequeBufferSize(#Canary) = SizeT(1);
 
 test() {
     println("making deque d1");
-    var d1 = Deque[Canary](Canary(), Canary(), Canary());
+    var d1 = deque(Canary(), Canary(), Canary());
 
     {
         println("copying deque d2");
@@ -24,7 +24,7 @@ test() {
     println("making deque d3 with exception");
     try {
         var thrower = Canary(true);
-        var d3 = Deque[Canary](Canary(), thrower, Canary());
+        var d3 = deque(Canary(), thrower, Canary());
     } catch(x) {}
 
     {
@@ -72,9 +72,9 @@ test() {
 
     {
         println("making deque d5");
-        var d5 = Deque[Canary](Canary(), Canary(), Canary(), Canary());
+        var d5 = deque(Canary(), Canary(), Canary(), Canary());
         println("making deque d6");
-        var d6 = Deque[Canary](Canary(), Canary());
+        var d6 = deque(Canary(), Canary());
 
         println("d1 assign longer");
         d1 = d5;
@@ -91,7 +91,7 @@ test() {
     clear(d7);
 
     println("making deque d8");
-    var d8 = Deque[Canary](
+    var d8 = deque(
         Canary(), Canary(), Canary(),
         Canary(), Canary(), Canary(),
         Canary(), Canary(), Canary(),
@@ -118,7 +118,7 @@ test() {
     checkCanariesLiveInSequence(d8);
 
     println("making deque d9");
-    var d9 = Deque[Canary](
+    var d9 = deque(
         Canary(), Canary(), Canary(),
         Canary(), Canary(), Canary(),
         Canary(), Canary(), Canary(),
@@ -154,7 +154,7 @@ test() {
     insert(d9, end(d9) - 2, Canary());
 
     println("making deque d10");
-    var d10 = Deque[Canary](Canary(), Canary(), Canary());
+    var d10 = deque(Canary(), Canary(), Canary());
 
     println("inserting d10 into d9 front");
     insertAll(d9, begin(d9), d10);
@@ -169,9 +169,9 @@ test() {
     insertAll(d9, end(d9) - 2, d10);
 
     println("making deque d11");
-    var d11 = Deque[Canary](Canary(), Canary(), Canary(), Canary());
+    var d11 = deque(Canary(), Canary(), Canary(), Canary());
     var thrower = Canary(true);
-    var throwerDeque = Deque[Canary](Canary(), Canary(true), Canary());
+    var throwerDeque = deque(Canary(), Canary(true), Canary());
     try {
         println("copying d12 from d11");
         var d12 = d11;

--- a/test/lib-clay/data/hashmaps/valueinitialization/main.clay
+++ b/test/lib-clay/data/hashmaps/valueinitialization/main.clay
@@ -20,7 +20,7 @@ main() {
     var vmap = HashMap[Int,Vector[Int]]();
 
     println(vmap[0]);
-    put(vmap, 0, Vector[Int](1,2,3));
+    put(vmap, 0, vector(1,2,3));
     remove(vmap, 0);
     println(vmap[0]);
 

--- a/test/lib-clay/data/queues/test.clay
+++ b/test/lib-clay/data/queues/test.clay
@@ -38,7 +38,7 @@ main() = testMain(
             expectEqual(0, queueSize(q));
         }),
         TestCase("queue constructors", -> {
-            var q1 = VectorQueue[Int](52, 42, 47);
+            var q1 = vectorQueue(52, 42, 47);
 
             expectEqual(3, queueSize(q1));
             expectEqual(52,  queuePop(q1));
@@ -46,7 +46,7 @@ main() = testMain(
             expectEqual(42,  queuePop(q1));
             expectTrue (queueEmpty?(q1));
 
-            var q2 = VectorQueue[Int](Vector[Int](52, 42, 47));
+            var q2 = VectorQueue[Int](vector(52, 42, 47));
 
             expectEqual(3, queueSize(q2));
             expectEqual(52,  queuePop(q2));
@@ -54,7 +54,7 @@ main() = testMain(
             expectEqual(42,  queuePop(q2));
             expectTrue (queueEmpty?(q2));
 
-            var q3 = VectorQueue[Int](Deque[Int](52, 42, 47));
+            var q3 = VectorQueue[Int](deque(52, 42, 47));
 
             expectEqual(3, queueSize(q3));
             expectEqual(52,  queuePop(q3));

--- a/test/lib-clay/data/sequences/1/main.clay
+++ b/test/lib-clay/data/sequences/1/main.clay
@@ -5,7 +5,7 @@ import data.vectors.*;
 even?(x) = (x % 2 == 0);
 
 main() {
-    var a = Vector[Int](1, 2, 3, 4, 5, 6);
+    var a = vector(1, 2, 3, 4, 5, 6);
     for (x in filtered(even?, a))
         x *: 10;
     var odd? = (x => x % 2 == 1);

--- a/test/lib-clay/data/sequences/2/main.clay
+++ b/test/lib-clay/data/sequences/2/main.clay
@@ -5,7 +5,7 @@ import data.vectors.*;
 double(x) = 2*x;
 
 main() {
-    var a = Vector[Int](1, 2, 3, 4, 5, 6);
+    var a = vector(1, 2, 3, 4, 5, 6);
     var b = mapped(addressOf, a);
     var c = mapped(dereference, b);
     for (x in c)

--- a/test/lib-clay/data/sequences/3/main.clay
+++ b/test/lib-clay/data/sequences/3/main.clay
@@ -3,8 +3,8 @@ import data.sequences.*;
 import data.vectors.*;
 
 main() {
-    var a = Vector[Int](1, 4, 9, 16, 25, 36);
-    var b = Vector[Int](6, 5, 4, 3, 2, 1);
+    var a = vector(1, 4, 9, 16, 25, 36);
+    var b = vector(6, 5, 4, 3, 2, 1);
     println("zipped");
     for (x, y in zipped(a, b))
         println(x, ", ", y);

--- a/test/lib-clay/data/sequences/4/main.clay
+++ b/test/lib-clay/data/sequences/4/main.clay
@@ -48,7 +48,7 @@ even?(x) = x % 2 == 0;
 main() {
     {
         // test enumerated
-        var a = Vector[Int](10, 20, 40, 80, 160);
+        var a = vector(10, 20, 40, 80, 160);
         for (i, x in enumerated(a))
             println(i, ") ", x);
     }
@@ -84,7 +84,7 @@ main() {
 
     {
         // test find, binarySearch
-        var a = Vector[Int](1, 1, 2, 4, 7, 7, 7, 9, 15, 15, 19);
+        var a = vector(1, 1, 2, 4, 7, 7, 7, 9, 15, 15, 19);
         printList(a);
         testFind(a, 10);
         testFind(a, 1);

--- a/test/lib-clay/data/sequences/concatenation/main.clay
+++ b/test/lib-clay/data/sequences/concatenation/main.clay
@@ -2,7 +2,7 @@ import printer.(println);
 import data.strings.*;
 import data.sequences.*;
 import data.sequences.operators.*;
-import data.vectors.(Vector);
+import data.vectors.*;
 
 main(){
 
@@ -22,5 +22,5 @@ main(){
     b ++: "ghi" ++ "jkl";
     println(b);
 
-    println(cat(Vector[Int](1,2,3), Vector[Int](4), Vector[Int](5,6)));
+    println(cat(vector(1,2,3), vector(4), vector(5,6)));
 }

--- a/test/lib-clay/data/sequences/ranges/main.clay
+++ b/test/lib-clay/data/sequences/ranges/main.clay
@@ -35,7 +35,7 @@ main() {
         println(i);
     println("size: ", size(reverseRange(0,1)));
     println("---");
-    var v = Vector[Int](0,1,2,3,4,5,6);
+    var v = vector(0,1,2,3,4,5,6);
     for (i in sliced(v,0,5))
         println(i);
     println("---");

--- a/test/lib-clay/data/strings/encodings/utf8/test.clay
+++ b/test/lib-clay/data/strings/encodings/utf8/test.clay
@@ -9,42 +9,42 @@ main() = testMain(
     TestSuite("utf8", array(
         TestCase("UTF8 well formed", -> {
             expectEqual(
-                Vector[Int](72, 32, 233, 32, 8364, 32, 119652),
+                vector(72, 32, 233, 32, 8364, 32, 119652),
                 map(Int, UTF8("H \xC3\xA9 \xE2\x82\xAC \xF0\x9D\x8D\xA4")));
         }),
         TestCase("UTF8 code point > 0x10FFFF", -> {
             expectEqual(
-                Vector[Int](65533, 32),
+                vector(65533, 32),
                 map(Int, UTF8("\xF4\xBF\xBF\xBF ")));
         }),
         TestCase("UTF8 invalid start characters", -> {
             expectEqual(
-                Vector[Int](65533, 65533, 65533),
+                vector(65533, 65533, 65533),
                 map(Int, UTF8("\x80\xBF\xF5\xFF")));
         }),
         TestCase("UTF8 truncated sequences", -> {
             ..for (s in "\xC3", "\xE2", "\xE2\x82", "\xF0", "\xF0\x9D", "\xF0\x9D\x8D") {
                 expectEqual(
-                    Vector[UniChar](UniChar(65533)),
+                    vector(UniChar(65533)),
                     UTF8(s));
             }
         }),
         TestCase("UTF8 invalid characters in sequences", -> {
             expectEqual(
-                Vector[Int](65533, 32, 65533, 32, 65533, 32, 65533, 32, 65533, 32, 65533, 32, 65533, 32),
+                vector(65533, 32, 65533, 32, 65533, 32, 65533, 32, 65533, 32, 65533, 32, 65533, 32),
                     
                 map(Int, UTF8(
                     "\xC3\x29 \xC3\xE9 \xE2\x02\xAC \xE2\x82\x2C \xF0\x1D\x8D\xA4 \xF0\x9D\x0D\xA4 \xF0\x9D\x8D\x24 ")));
         }),
         TestCase("UTF8 invalid overlond encodings", -> {
             expectEqual(
-                Vector[Int](65533, 32, 65533, 32, 128, 32),
+                vector(65533, 32, 65533, 32, 128, 32),
                 map(Int, UTF8("\xC0\x80 \xC1\xBF \xC2\x80 ")));
             expectEqual(
-                Vector[Int](65533, 32, 65533, 32, 2048, 32),
+                vector(65533, 32, 65533, 32, 2048, 32),
                 map(Int, UTF8("\xE0\x80\x80 \xE0\x9F\xBF \xE0\xA0\x80 ")));
             expectEqual(
-                Vector[Int](65533, 32, 65533, 32, 65536, 32),
+                vector(65533, 32, 65533, 32, 65536, 32),
                 map(Int, UTF8("\xF0\x80\x80\x80 \xF0\x8F\xBF\xBF \xF0\x90\x80\x80 ")));
         }),
         TestCase("UTF8 push", -> {
@@ -64,7 +64,7 @@ main() = testMain(
                 "\0\x7F\xC2\x80\xDF\xBF\xE0\xA0\x80\xEF\xBF\xBF\xF0\x90\x80\x80\xF4\x8F\xBF\xBF\xEF\xBF\xBD",
                 ustr.encoded);
             expectEqual(
-                Vector[Int](0, 127, 128, 2047, 2048, 65535, 65536, 1114111, 65533),
+                vector(0, 127, 128, 2047, 2048, 65535, 65536, 1114111, 65533),
                 map(Int, ustr));
         }),
         TestCase("encodeUniChar", -> {

--- a/test/lib-clay/interfaces/main.clay
+++ b/test/lib-clay/interfaces/main.clay
@@ -13,7 +13,7 @@ main() {
     var objects = array(
         allocateBox(TestInterface, "hello world"),
         allocateBox(TestInterface, array(1, 2, 3, 4)),
-        allocateBox(TestInterface, Vector[Float](5.0f, 6.0f, 7.0f)),
+        allocateBox(TestInterface, vector(5.0f, 6.0f, 7.0f)),
     );
 
     for (object in objects) {

--- a/test/lib-clay/lambdas/dynamic/main.clay
+++ b/test/lib-clay/lambdas/dynamic/main.clay
@@ -14,7 +14,7 @@ makeFuncs() {
 
     alias F = Function[[Int], [Int]];
 
-    return Vector[F](F(double), F(triple), F(plus2), F(plus3));
+    return vector(F(double), F(triple), F(plus2), F(plus3));
 }
 
 main() {

--- a/test/lib-clay/parsing/combinators/generic/test.clay
+++ b/test/lib-clay/parsing/combinators/generic/test.clay
@@ -32,7 +32,7 @@ testSeparatedListNotEmpty(#strict, #opt) {
     var s = String("1.12.xy");
     var input = iterator(s);
     var r = require(p(input));
-    var expected = Vector[Int](1, 12);
+    var expected = vector(1, 12);
     expectEqual(expected, r);
     if (strict) {
         expectEqual(String(".xy"), String(input));

--- a/test/lib-clay/printing/1/test.clay
+++ b/test/lib-clay/printing/1/test.clay
@@ -37,7 +37,7 @@ main() = testMain(
             expectPrinted("{10, 20, 30}", array(10, 20, 30));
         }),
         TestCase("vector", -> {
-            expectPrinted("{true, false, true}", Vector[Bool](true, false, true));
+            expectPrinted("{true, false, true}", vector(true, false, true));
         }),
         TestCase("CStringRef", -> {
             expectPrinted("aaa", CStringRef(cstring("aaa")));

--- a/test/lib-clay/remote/marshaling/test.clay
+++ b/test/lib-clay/remote/marshaling/test.clay
@@ -95,13 +95,13 @@ main() = testMain(
         }),
         TestCase("sequences", -> {
             expectMarshalingInvariants(
-                Vector[Int](1, 2, 3)
+                vector(1, 2, 3)
             );
             expectMarshalingInvariants(
                 String("crenshaw")
             );
             expectMarshalingInvariants(
-                Vector[String](String("crenshaw"), String("mathers"))
+                vector(String("crenshaw"), String("mathers"))
             );
             expectMarshalingInvariants(
                 String(),
@@ -118,22 +118,22 @@ main() = testMain(
         }),
         TestCase("composites", -> {
             expectMarshalingInvariants(
-                [1, Vector[Int](1, 2, 3), 'a']
+                [1, vector(1, 2, 3), 'a']
             );
             expectMarshalingInvariants(
-                [1, Vector[Int](1, 2, 3), 'a']
+                [1, vector(1, 2, 3), 'a']
             );
             expectMarshalingInvariants(
-                ComplexRecord(1, Vector[Int](1, 2, 3), 'a')
+                ComplexRecord(1, vector(1, 2, 3), 'a')
             );
             expectMarshalingInvariants(
                 [ReferenceRecord(3), ReferenceRecord(5)]
             );
             expectMarshalingInvariants(
-                Vector[ReferenceRecord](ReferenceRecord(3), ReferenceRecord(5)),
+                vector(ReferenceRecord(3), ReferenceRecord(5)),
             );
             expectMarshalingInvariants(
-                [ReferenceRecord(3), Vector[ReferenceRecord](ReferenceRecord(3), ReferenceRecord(5))],
+                [ReferenceRecord(3), vector(ReferenceRecord(3), ReferenceRecord(5))],
             );
             expectMarshalingInvariants(
                 Range[Int](1, 3),
@@ -155,7 +155,7 @@ main() = testMain(
                 TestVariant(0.0)
             );
             expectMarshalingInvariants(
-                TestVariant(Vector[Int](1, 2, 3))
+                TestVariant(vector(1, 2, 3))
             );
         }),
         TestCase("statics", -> {
@@ -166,8 +166,8 @@ main() = testMain(
         TestCase("lambdas", -> {
             var int = 1;
             var char = 'a';
-            var vectorInt = Vector[Int](1, 2, 3);
-            var vectorString = Vector[String](String("crenshaw"), String("mathers"));
+            var vectorInt = vector(1, 2, 3);
+            var vectorString = vector(String("crenshaw"), String("mathers"));
 
             expectMarshalingInvariants(() => int);
             expectMarshalingInvariants(() => char);

--- a/test/lib-clay/test/repr/main.clay
+++ b/test/lib-clay/test/repr/main.clay
@@ -16,7 +16,7 @@ main() = testMain(
                 expectEqualValues(['\r', "x\t"], '\x12', "x\t");
             }),
             TestCase("in expectIterator and expectSequence", -> {
-                var vs = Vector[UInt32](1u, 17u);
+                var vs = vector(1u, 17u);
                 expectIterator(iterator(vs), 4u);
                 expectSequence(vs, 12u);
             }),

--- a/test/lib-clay/uniquepointers/main.clay
+++ b/test/lib-clay/uniquepointers/main.clay
@@ -5,7 +5,7 @@ import data.vectors.*;
 test() {
     var p = newUnique(Canary(true));
 
-    var pv = Vector[UniquePointer[Canary]](
+    var pv = vector(
         newUnique(Canary(true)),
         newUnique(Canary(true)),
         newUnique(Canary(true)),


### PR DESCRIPTION
Before this commit `Vector` functions were over-overloaded: call
to

```
Vector[T](a)
```

could interpret `a` as a sequence or as an element parameter. This
is over-overloading that make code harder to read and maintain.

This commit changes sequence construction API. New convention is
proposed:

Let `Foo` be sequence type.

Calls

```
Foo(arg)
Foo[T](arg)
```

assume arg is a sequence. Call

```
foo(..args)
```

interpret args as elements for new foo sequence. Latter call does
not work when args list is empty (because type parameter for `Foo`
cannot be infered and thus must be specified).

To deal with this problem, `elements` function is proposed:

```
Foo[T](elements(..args))
```

`elements` function with non-empty parameters list returns an array
of arguments, and `elements` with empty args returns special
sequence-like record NoElements, that has no type parameter (thus
`elements()` call does not fail, unlike `vector()`).

This patch changes vector, vectorQueue and deque.
### Alternative version

Alternative version of this pull request: #483, that uses tuples for parameters instead of `elements` function.
