### PR TITLE
set TargetOptions before passing to createTargetMachine

### DIFF
--- a/compiler/codegen.cpp
+++ b/compiler/codegen.cpp
@@ -7248,17 +7248,17 @@ llvm::TargetMachine *initLLVM(llvm::StringRef targetTriple,
     default : level = llvm::CodeGenOpt::Aggressive; break;
     }
 
+    llvm::TargetOptions opts;
+    if (optLevel < 2 || debug)
+        opts.NoFramePointerElim = 1;
+    if (softFloat) {
+        opts.UseSoftFloat = 1;
+        opts.FloatABIType = llvm::FloatABI::Soft;
+    }
+
     llvm::TargetMachine *targetMachine = target->createTargetMachine(
         targetTriple, targetCPU, targetFeatures,
-        llvm::TargetOptions(), reloc, codeModel, level);
-
-    if (optLevel < 2 || debug)
-        targetMachine->Options.NoFramePointerElim = 1;
-
-    if (softFloat) {
-        targetMachine->Options.UseSoftFloat = 1;
-        targetMachine->Options.FloatABIType = llvm::FloatABI::Soft;
-    }
+        opts, reloc, codeModel, level);
 
     if (targetMachine != NULL) {
         llvmDataLayout = targetMachine->getDataLayout();


### PR DESCRIPTION
When testing MIPS ABI, I found that LLVM generated FP instructions even though soft-float was set.

It seems that options do not have any effect if we set them after createTargetMachine.
