### PR TITLE
evalStringTableConstant: write trailing \0 into correct location

### DIFF
--- a/compiler/evaluator_op.cpp
+++ b/compiler/evaluator_op.cpp
@@ -1038,7 +1038,7 @@ static const void *evalStringTableConstant(llvm::StringRef s)
         error("unsupported pointer width");
     }
     memcpy((void*)((char*)buf + bits), (const void*)s.begin(), s.size());
-    ((char*)buf)[s.size()] = 0;
+    ((char*)buf)[bits + s.size()] = 0;
     staticStringTableConstants[s] = (const void*)buf;
     return buf;
 }


### PR DESCRIPTION
I found a bug in code, but I cannot reproduce it. `evalStringTableConstant` function is called (I checked in debugger), but result seems to be ignored somehow. For instance, I tried this test:

```
println(#(stringTableConstant("abc")^));
```

It outputs `3`, and not junk as I thought.

Any idea how to write a unit test for the issue?
